### PR TITLE
ci(renovate): use npm for post-upgrade build instead of mise

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -5,7 +5,10 @@
   // the repo with no install step. A dependency bump is therefore only real once
   // the bundle is rebuilt; CI's build-check gate fails the PR until it is.
   postUpgradeTasks: {
-    commands: ["mise run build"],
+    // mise isn't on PATH in the Renovate container, so call npm directly here.
+    // mise.toml's build task is just `npm ci` + `npm run build`; CI still runs
+    // `mise run build-check` to gate the committed bundle on the pinned toolchain.
+    commands: ["npm ci", "npm run build"],
     fileFilters: ["dist/**"],
     executionMode: "branch",
   },


### PR DESCRIPTION
## What

Change the Renovate `postUpgradeTasks` command from `mise run build` to `npm ci` + `npm run build`.

## Why

`mise` is not installed in the Renovate container, so the post-upgrade task failed with:

```
Error: spawn mise ENOENT
```

Renovate raised an "⚠️ Artifact update problem" and never rebuilt `dist/` (see #5). The `mise run build` task is just `npm ci` + `npm run build`, so calling npm directly - it is available in the container - rebuilds the committed bundle without depending on mise.

CI still runs `mise run build-check` on a normal runner (where mise is present) to gate the bundle on the pinned toolchain, so nothing about the local/dev workflow changes.

Requires the companion allowlist change in home-operations/.github#39.