### PR TITLE
feat: support leaving nodes in maintenance mode

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -60,6 +60,12 @@ jobs:
           # dropped. Needs no KVM, so it is also the fast leg.
           - example: docker
             nodes: 2
+          # The maintenance preset: nodes boot and stay unconfigured, so no cluster
+          # forms, kubectl never applies, and the hand-off is the node addresses plus
+          # an empty kubeconfig output. Verified over the insecure maintenance API.
+          - example: maintenance
+            nodes: 1
+            maintenance: true
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -107,6 +113,7 @@ jobs:
           config: examples/${{ matrix.example }}.yaml
 
       - name: Verify the cluster came up
+        if: ${{ !matrix.maintenance }}
         env:
           EXPECTED_NODES: ${{ matrix.nodes }}
           ENDPOINT: ${{ steps.cluster.outputs.endpoint }}
@@ -122,15 +129,47 @@ jobs:
           # drifts from what the provisioner did, every downstream step misfires.
           talosctl -n "$ENDPOINT" version --short
 
+      # Nodes in maintenance mode never form a cluster, so the check is the inverse
+      # of the kubectl one: the insecure maintenance API answers, the kubeconfig
+      # output is empty, and neither KUBECONFIG nor TALOSCONFIG was exported into
+      # this step's environment.
+      - name: Verify the nodes are in maintenance mode
+        if: matrix.maintenance
+        env:
+          CONTROLPLANE_IPS: ${{ steps.cluster.outputs.controlplane-ips }}
+          KUBECONFIG_OUT: ${{ steps.cluster.outputs.kubeconfig }}
+        run: |
+          if [[ -n "$KUBECONFIG_OUT" ]]; then
+            echo "::error::kubeconfig output should be empty in maintenance mode, got $KUBECONFIG_OUT"
+            exit 1
+          fi
+          if [[ -n "${KUBECONFIG:-}${TALOSCONFIG:-}" ]]; then
+            echo "::error::KUBECONFIG/TALOSCONFIG must not be exported in maintenance mode"
+            exit 1
+          fi
+
+          node="${CONTROLPLANE_IPS%%,*}"
+          # Create returns as soon as the VMs launch, so the API needs a moment to
+          # start answering.
+          echo "waiting for the maintenance API on $node"
+          timeout 5m bash -c "until talosctl -n \"$node\" get links --insecure >/dev/null 2>&1; do sleep 5; done"
+          talosctl -n "$node" get links --insecure
+
       - name: Verify the reported outputs
         env:
           EXAMPLE: ${{ matrix.example }}
+          MAINTENANCE: ${{ matrix.maintenance }}
           PROVIDER: ${{ steps.cluster.outputs.provider }}
           KUBECONFIG_OUT: ${{ steps.cluster.outputs.kubeconfig }}
           TALOSCONFIG_OUT: ${{ steps.cluster.outputs.talosconfig }}
           SCHEMATIC_ID: ${{ steps.cluster.outputs.schematic-id }}
         run: |
-          test -s "$KUBECONFIG_OUT" || { echo "::error::kubeconfig output is empty"; exit 1; }
+          # In maintenance mode no kubeconfig exists; its emptiness is asserted in the
+          # step above. The talosconfig is still written next to the generated machine
+          # configs in both modes.
+          if [[ "$MAINTENANCE" != "true" ]]; then
+            test -s "$KUBECONFIG_OUT" || { echo "::error::kubeconfig output is empty"; exit 1; }
+          fi
           test -s "$TALOSCONFIG_OUT" || { echo "::error::talosconfig output is empty"; exit 1; }
 
           expected=qemu

--- a/README.md
+++ b/README.md
@@ -333,6 +333,52 @@ and passed through as `--image-factory-auth`; it is registered as a secret, so t
 runner masks it in the command line the log echoes. Keep it in a GitHub secret rather
 than committing it, and note it needs talosctl v1.13 or newer.
 
+### Maintenance mode
+
+talosctl's `maintenance` preset ("Skip applying machine configuration and leave the
+machines in maintenance mode") passes through like any other, and the action detects
+it. That turns the action into a "give me unconfigured Talos nodes on this runner"
+primitive for repos that bring their own config management: an e2e workflow for a
+cluster template can exercise its real bootstrap flow against freshly booted nodes,
+the same way a user would against bare metal.
+
+```yaml
+spec:
+  controlplanes:
+    count: 1
+  workers:
+    count: 0
+  qemu:
+    presets: [iso, maintenance]
+```
+
+No cluster forms behind the nodes, so the action skips the kubeconfig fetch and
+exports neither `KUBECONFIG` nor `TALOSCONFIG`; the `kubeconfig` output is empty.
+The hand-off is the `controlplane-ips`, `worker-ips`, and `gateway` outputs: the
+nodes answer on the insecure maintenance API, and your tooling takes it from there.
+
+```yaml
+- uses: home-operations/talosctl-cluster-action@v1
+  id: cluster
+  with:
+    config: test/e2e/maintenance.yaml
+
+- run: talosctl -n "${IPS%%,*}" get links --insecure
+  env:
+    IPS: ${{ steps.cluster.outputs.controlplane-ips }}
+```
+
+Three details worth knowing:
+
+- **Create returns as soon as the VMs launch**, since there is no configuration to
+  wait on. Give the maintenance API a moment to start answering, or poll it.
+- **Machine configs are still generated**, with the profile and any
+  `spec.config-patches` folded in; they are written to `config-dir` but never
+  applied, and the `talosconfig` output points at the matching client config. Apply
+  them yourself or ignore them entirely.
+- **The post-step teardown is unchanged**: the nodes and their network are destroyed
+  at the end of the job as usual.
+
 ## Using it in a matrix
 
 Testing several cluster shapes is the common case: one leg per shape, each on its own
@@ -457,6 +503,9 @@ Three things worth knowing before you scale the matrix out:
 | `gateway`          | Host end of the QEMU bridge (first address in the CIDR).  |
 | `controlplane-ips` | Comma-separated control plane addresses.                  |
 | `worker-ips`       | Comma-separated worker addresses.                         |
+
+Under the [maintenance preset](#maintenance-mode) `kubeconfig` is empty and neither
+environment variable is exported; everything else is emitted as usual.
 
 ## Notes
 

--- a/action.yaml
+++ b/action.yaml
@@ -40,9 +40,14 @@ outputs:
   provider:
     description: Provisioner the cluster was created with, qemu or docker.
   kubeconfig:
-    description: Path to the generated kubeconfig. Also exported as $KUBECONFIG.
+    description: >-
+      Path to the generated kubeconfig. Also exported as $KUBECONFIG. Empty when
+      the maintenance preset leaves the nodes unconfigured, since no cluster forms.
   talosconfig:
-    description: Path to the generated talosconfig. Also exported as $TALOSCONFIG.
+    description: >-
+      Path to the generated talosconfig. Also exported as $TALOSCONFIG, except under
+      the maintenance preset, where its certs match machine configs that were never
+      applied; the file is still written next to those configs.
   schematic-id:
     description: Image Factory schematic id the nodes booted from, if one was used.
   endpoint:

--- a/dist/index.js
+++ b/dist/index.js
@@ -44404,7 +44404,7 @@ var properties = {
 						}
 					},
 					presets: {
-						description: "Boot presets. Maps to --presets. Exactly one of iso, iso-secureboot, pxe, or disk-image must be present.",
+						description: "Boot presets. Maps to --presets. Exactly one of iso, iso-secureboot, pxe, or disk-image must be present. Adding maintenance leaves the nodes unconfigured in maintenance mode: the action then skips the kubeconfig fetch and exports neither KUBECONFIG nor TALOSCONFIG, handing over only the node addresses.",
 						type: "array",
 						minItems: 1,
 						items: {
@@ -44481,6 +44481,13 @@ const withV = (v) => (String(v).startsWith("v") ? String(v) : `v${v}`);
 const withoutV = (v) => String(v).replace(/^v/, "");
 
 const providerOf = (cluster) => cluster.spec?.provider ?? DEFAULT_PROVIDER;
+
+// talosctl's maintenance preset boots the nodes but applies no machine config, so no
+// cluster ever forms behind them. main.js keys off this to skip the kubeconfig fetch
+// and the KUBECONFIG/TALOSCONFIG exports, which would otherwise point later steps at
+// a cluster that does not exist.
+const hasMaintenancePreset = (cluster) =>
+  Boolean(cluster.spec?.qemu?.presets?.includes("maintenance"));
 
 function buildArgs(cluster, ctx = {}) {
   const spec = cluster.spec ?? {};
@@ -45463,16 +45470,28 @@ async function run() {
 
   const endpoint = addresses.controlplanes[0];
 
-  await exec(talosctl, ["kubeconfig", kubeconfig, "--nodes", endpoint, "--force"], {
-    env: { ...process.env, TALOSCONFIG: talosconfig },
-  });
+  // The maintenance preset leaves the nodes unconfigured, so there is no cluster to
+  // fetch a kubeconfig from, and the generated talosconfig's certs match machine
+  // configs that were never applied. Exporting either would point later steps, or the
+  // caller's own bootstrap tooling, at a cluster that does not exist. The node
+  // addresses are the whole hand-off; the nodes answer on the insecure maintenance
+  // API (`talosctl -n <ip> --insecure`).
+  const maintenance = hasMaintenancePreset(cluster);
 
-  exportVariable("TALOSCONFIG", talosconfig);
-  exportVariable("KUBECONFIG", kubeconfig);
+  if (!maintenance) {
+    await exec(talosctl, ["kubeconfig", kubeconfig, "--nodes", endpoint, "--force"], {
+      env: { ...process.env, TALOSCONFIG: talosconfig },
+    });
+
+    exportVariable("TALOSCONFIG", talosconfig);
+    exportVariable("KUBECONFIG", kubeconfig);
+  }
 
   setOutput("cluster-name", name);
   setOutput("provider", provider);
-  setOutput("kubeconfig", kubeconfig);
+  setOutput("kubeconfig", maintenance ? "" : kubeconfig);
+  // Still written by `cluster create` in maintenance mode, alongside the generated
+  // machine configs it belongs to; it becomes valid if the caller applies them.
   setOutput("talosconfig", talosconfig);
   setOutput("schematic-id", schematicId ?? "");
   setOutput("endpoint", endpoint);
@@ -45480,7 +45499,11 @@ async function run() {
   setOutput("controlplane-ips", addresses.controlplanes.join(","));
   setOutput("worker-ips", addresses.workers.join(","));
 
-  info(`Cluster '${name}' ready at ${endpoint}`);
+  info(
+    maintenance
+      ? `Cluster '${name}' nodes booted in maintenance mode; first node at ${endpoint}`
+      : `Cluster '${name}' ready at ${endpoint}`,
+  );
 }
 
 run().catch((err) => setFailed(err.message));

--- a/examples/maintenance.yaml
+++ b/examples/maintenance.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/home-operations/talosctl-cluster-action/main/schema/talos-cluster.json
+# The maintenance preset: nodes boot from the ISO and stay unconfigured, for repos
+# that bring their own bootstrap tooling and want to exercise it against fresh nodes
+# the way it would run against bare metal. No cluster forms, so the action skips the
+# kubeconfig fetch and hands over only the node addresses; the nodes answer on the
+# insecure maintenance API (`talosctl -n <ip> get links --insecure`).
+apiVersion: v1alpha1
+kind: TalosCluster
+metadata:
+  name: maint
+spec:
+  controlplanes:
+    count: 1
+  workers:
+    count: 0
+  qemu:
+    presets: [iso, maintenance]

--- a/schema/talos-cluster.json
+++ b/schema/talos-cluster.json
@@ -168,7 +168,7 @@
               }
             },
             "presets": {
-              "description": "Boot presets. Maps to --presets. Exactly one of iso, iso-secureboot, pxe, or disk-image must be present.",
+              "description": "Boot presets. Maps to --presets. Exactly one of iso, iso-secureboot, pxe, or disk-image must be present. Adding maintenance leaves the nodes unconfigured in maintenance mode: the action then skips the kubeconfig fetch and exports neither KUBECONFIG nor TALOSCONFIG, handing over only the node addresses.",
               "type": "array",
               "minItems": 1,
               "items": { "enum": ["iso", "iso-secureboot", "pxe", "disk-image", "maintenance"] }

--- a/src/args.js
+++ b/src/args.js
@@ -18,6 +18,13 @@ const withoutV = (v) => String(v).replace(/^v/, "");
 
 export const providerOf = (cluster) => cluster.spec?.provider ?? DEFAULT_PROVIDER;
 
+// talosctl's maintenance preset boots the nodes but applies no machine config, so no
+// cluster ever forms behind them. main.js keys off this to skip the kubeconfig fetch
+// and the KUBECONFIG/TALOSCONFIG exports, which would otherwise point later steps at
+// a cluster that does not exist.
+export const hasMaintenancePreset = (cluster) =>
+  Boolean(cluster.spec?.qemu?.presets?.includes("maintenance"));
+
 export function buildArgs(cluster, ctx = {}) {
   const spec = cluster.spec ?? {};
   const provider = providerOf(cluster);

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import * as core from "@actions/core";
 import { exec } from "@actions/exec";
 
 import { loadCluster, validateSocketPath } from "./config.js";
-import { buildArgs, nodeAddresses, providerOf, withV } from "./args.js";
+import { buildArgs, hasMaintenancePreset, nodeAddresses, providerOf, withV } from "./args.js";
 import {
   concatPatches,
   resolveProfilePatches,
@@ -152,16 +152,28 @@ export async function run() {
 
   const endpoint = addresses.controlplanes[0];
 
-  await exec(talosctl, ["kubeconfig", kubeconfig, "--nodes", endpoint, "--force"], {
-    env: { ...process.env, TALOSCONFIG: talosconfig },
-  });
+  // The maintenance preset leaves the nodes unconfigured, so there is no cluster to
+  // fetch a kubeconfig from, and the generated talosconfig's certs match machine
+  // configs that were never applied. Exporting either would point later steps, or the
+  // caller's own bootstrap tooling, at a cluster that does not exist. The node
+  // addresses are the whole hand-off; the nodes answer on the insecure maintenance
+  // API (`talosctl -n <ip> --insecure`).
+  const maintenance = hasMaintenancePreset(cluster);
 
-  core.exportVariable("TALOSCONFIG", talosconfig);
-  core.exportVariable("KUBECONFIG", kubeconfig);
+  if (!maintenance) {
+    await exec(talosctl, ["kubeconfig", kubeconfig, "--nodes", endpoint, "--force"], {
+      env: { ...process.env, TALOSCONFIG: talosconfig },
+    });
+
+    core.exportVariable("TALOSCONFIG", talosconfig);
+    core.exportVariable("KUBECONFIG", kubeconfig);
+  }
 
   core.setOutput("cluster-name", name);
   core.setOutput("provider", provider);
-  core.setOutput("kubeconfig", kubeconfig);
+  core.setOutput("kubeconfig", maintenance ? "" : kubeconfig);
+  // Still written by `cluster create` in maintenance mode, alongside the generated
+  // machine configs it belongs to; it becomes valid if the caller applies them.
   core.setOutput("talosconfig", talosconfig);
   core.setOutput("schematic-id", schematicId ?? "");
   core.setOutput("endpoint", endpoint);
@@ -169,7 +181,11 @@ export async function run() {
   core.setOutput("controlplane-ips", addresses.controlplanes.join(","));
   core.setOutput("worker-ips", addresses.workers.join(","));
 
-  core.info(`Cluster '${name}' ready at ${endpoint}`);
+  core.info(
+    maintenance
+      ? `Cluster '${name}' nodes booted in maintenance mode; first node at ${endpoint}`
+      : `Cluster '${name}' ready at ${endpoint}`,
+  );
 }
 
 run().catch((err) => core.setFailed(err.message));

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { buildArgs, nodeAddresses } from "../src/args.js";
+import { buildArgs, hasMaintenancePreset, nodeAddresses } from "../src/args.js";
 
 const cluster = (spec) => ({
   apiVersion: "v1alpha1",
@@ -90,6 +90,22 @@ describe("buildArgs", () => {
     });
     assert.equal(valueOf(args, "--schematic-id"), "abc123");
     assert.equal(valueOf(args, "--talosconfig-destination"), "/tmp/dev/talosconfig");
+  });
+});
+
+describe("hasMaintenancePreset", () => {
+  it("detects the maintenance preset among the boot presets", () => {
+    assert.equal(
+      hasMaintenancePreset(cluster({ qemu: { presets: ["iso", "maintenance"] } })),
+      true,
+    );
+  });
+
+  it("is false without it", () => {
+    assert.equal(hasMaintenancePreset(cluster()), false);
+    assert.equal(hasMaintenancePreset(cluster({})), false);
+    assert.equal(hasMaintenancePreset(cluster({ qemu: {} })), false);
+    assert.equal(hasMaintenancePreset(cluster({ qemu: { presets: ["iso"] } })), false);
   });
 });
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -60,5 +60,17 @@ echo "==> outputs"
 cat "${workdir}/output"
 
 kubeconfig="$(value_of kubeconfig "${workdir}/output")"
-KUBECONFIG="${kubeconfig}" kubectl wait --for=condition=Ready node --all --timeout=5m
-KUBECONFIG="${kubeconfig}" kubectl get nodes -o wide
+
+# An empty kubeconfig means the maintenance preset: no cluster formed, so verify the
+# nodes over the insecure maintenance API instead. Create returns as soon as the VMs
+# launch, so the API needs a moment to start answering.
+if [[ -z "${kubeconfig}" ]]; then
+    node="$(value_of controlplane-ips "${workdir}/output")"
+    node="${node%%,*}"
+    echo "==> waiting for the maintenance API on ${node}"
+    timeout 5m bash -c "until talosctl -n '${node}' get links --insecure >/dev/null 2>&1; do sleep 5; done"
+    talosctl -n "${node}" get links --insecure
+else
+    KUBECONFIG="${kubeconfig}" kubectl wait --for=condition=Ready node --all --timeout=5m
+    KUBECONFIG="${kubeconfig}" kubectl get nodes -o wide
+fi


### PR DESCRIPTION
Closes #10.

Makes the action usable as a "give me maintenance-mode Talos VMs on a runner" primitive for repos that bring their own config management, while changing nothing for the default path.

## Approach

Rather than adding a new `TalosCluster` spec field, the action detects talosctl's own `maintenance` preset in `spec.qemu.presets`, which it already passes through as `--presets`. talosctl handles most of the issue's list itself: the preset sets `SkipInjectingConfig`/`ApplyConfigEnabled=false`, and `postCreate` saves the talosconfig and returns before bootstrap and the readiness wait. What broke was only the action's own post-create step, which unconditionally fetched a kubeconfig from a cluster that never forms.

With the preset present, the action now:

- skips the `talosctl kubeconfig` fetch and exports neither `KUBECONFIG` nor `TALOSCONFIG`, so later steps and the caller's bootstrap tooling are not pointed at a cluster that does not exist
- emits an empty `kubeconfig` output, and keeps the `endpoint` / `gateway` / `controlplane-ips` / `worker-ips` outputs so the workflow can reach the nodes' insecure maintenance API
- keeps the `talosconfig` output pointing at the file `cluster create` still writes: its certs match the generated-but-unapplied machine configs in `config-dir`, and it becomes valid if the caller applies them
- leaves the post-step `cluster destroy` teardown unchanged

## Changes

- `src/args.js`: `hasMaintenancePreset()` helper
- `src/main.js`: skip the kubeconfig fetch and env exports in maintenance mode
- `schema/talos-cluster.json`, `action.yaml`, `README.md`: document the behavior
- `examples/maintenance.yaml`: minimal maintenance-mode spec, picked up by the example tests
- `.github/workflows/e2e.yaml`: new `maintenance` matrix leg that asserts the kubeconfig output is empty, neither env var is exported, and the insecure maintenance API (`talosctl -n <ip> get links --insecure`) answers
- `test/e2e.sh`: verifies over the insecure API when the kubeconfig output is empty, so `test/e2e.sh maintenance` works locally
- `test/args.test.js`: unit tests for the preset detection
- `dist/`: rebuilt bundle

## Testing

- `mise run test`: 116 tests pass, including the new preset-detection tests and validation of the new example
- `mise run lint`: clean (oxlint, zizmor, shellcheck)
- The new e2e leg exercises the full flow on this PR's CI run