### PR TITLE
chore(renovate): group Talos updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -8,6 +8,12 @@
   },
   packageRules: [
     {
+      description: "Update the Talos release and talosctl together",
+      matchPackageNames: ["siderolabs/talos", "talosctl"],
+      groupName: "Talos Group",
+      minimumGroupSize: 2,
+    },
+    {
       description: "Keep the Node toolchain on the major that matches the action runtime",
       matchManagers: ["mise"],
       matchPackageNames: ["node"],


### PR DESCRIPTION
## Summary

- group `siderolabs/talos` and `talosctl` updates as `Talos Group`
- require both updates with `minimumGroupSize: 2`

This keeps the updates currently split across #13 and #14 in sync.

## Validation

- `renovate-config-validator .renovaterc.json5`
- pre-commit hooks