### PR TITLE
docs: clarify the runner swapfile is host swap, not cluster swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,12 @@ mutation in your workflow, where you can see it. Both providers need `talosctl`
     sudo apt-get update
     sudo apt-get install -y --no-install-recommends qemu-system-x86 qemu-utils ovmf
 
-# Headroom for the upgrade phase, when each node unpacks an installer alongside etcd
-# and the API server. Its own file, so it adds to the runner's existing swap. Skip it
-# and a 16GB runner will OOM mid-upgrade, which reads as a flaky test.
+# Runner swap, for the runner's own kernel, not the cluster. The nodes are QEMU VMs,
+# so their RAM is ordinary host memory: under an upgrade's transient spike (each node
+# unpacking an installer alongside etcd and the API server) the kernel pages a QEMU
+# process out to here instead of OOM-killing it, which would read as a flaky test. The
+# guest never sees this swap, so it needs no Talos or kubelet config. Its own file, so
+# it adds to the runner's existing swap; skip it and a 16GB runner OOMs mid-upgrade.
 - name: Enable swap
   run: |
     sudo fallocate -l 8G /mnt/e2e-swapfile


### PR DESCRIPTION
## What

Rewords the `Enable swap` comment in the README's qemu runner setup so it's clear the `/mnt/e2e-swapfile` is the **runner's own swap**, not swap the cluster uses.

## Why

The old comment framed the swapfile purely as "upgrade headroom." That reads as swap the cluster consumes, which raises a fair question: why does it help when Talos and the kubelet keep swap off by default (and only enable it via explicit [Talos `machine.swap`](https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/swap) / [k8s `NodeSwap`](https://kubernetes.io/docs/concepts/cluster-administration/swap-memory-management/) config)?

Those docs are about a **different layer**. The nodes here are QEMU VMs, so a guest's RAM is ordinary anonymous memory in the `qemu-system` process. The runner's own kernel can page that out to the swapfile under a transient upgrade spike (installer unpack alongside etcd + the API server) instead of OOM-killing a QEMU process, which would surface as a flaky test. The guest never touches this swap, so it needs no Talos or kubelet config. The new comment says exactly that.

Docs-only; no code or `dist/` change.