### PR TITLE
ci: skip release-please PRs in checks and drop nightly e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,20 +3,12 @@
 name: E2E
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "**.md"
-      - ".release-please-manifest.json"
   pull_request:
     branches:
       - main
     paths-ignore:
       - "**.md"
       - ".release-please-manifest.json"
-  schedule:
-    - cron: "30 5 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -32,6 +24,9 @@ env:
 
 jobs:
   e2e:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: E2E (${{ matrix.example }})
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,9 @@ permissions:
 
 jobs:
   lint:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Lint
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,9 @@ permissions:
 
 jobs:
   test:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Unit Tests
     runs-on: ubuntu-24.04
     permissions:
@@ -46,6 +49,9 @@ jobs:
         run: mise run test
 
   build-check:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Bundle Freshness
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
Two changes, part of an org-wide CI conformity / minutes pass.

**1. Skip only genuine release-please PRs**, using a signal a contributor can't forge:

```yaml
if: >-
  ${{ !(startsWith(github.head_ref, 'release-please--')
  && github.event.pull_request.head.repo.full_name == github.repository) }}
```

`head_ref` alone (the PR's source branch name) is settable by anyone, including from a fork, so a `release-please--*` branch could skip every check. Requiring the PR head repo to be this repo means fork PRs - the realistic path for outside contributors - always run the full suite.

**2. Run e2e on pull requests and workflow_dispatch only.** Dropped both the nightly `schedule` and the redundant `push: main` run (a merged PR already ran e2e).
