### PR TITLE
feat(profile): drop NTP and discovery from the ephemeral profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,17 @@ makes your cluster different:
 | `init_on_alloc=0`                                                 | Zeroing every allocation costs cycles in a throwaway guest. |
 | kubelet `imageGCHighThresholdPercent` + `evictionHard` at zero    | Stops image GC and pod eviction from reading as flakes.     |
 | kubelet `serializeImagePulls: false` (`maxParallelImagePulls: 3`) | Pulls images in parallel, the slowest part of a cold start. |
+| `machine.time.disabled`                                           | NTP sync gates etcd, the kubelet and trustd on every boot.  |
+| `cluster.discovery.enabled: false`                                | Nothing local needs the public discovery service.           |
 | etcd `unsafe-no-fsync`                                            | Durability for I/O, on a cluster about to be deleted.       |
 | apiserver `auditPolicy: None`                                     | Talos logs every request to disk by default.                |
 | `machine.install.image` pinned to the schematic                   | Only when a schematic is used; see below.                   |
+
+`mitigations=off` does not cover page-table isolation, and nothing can make it. Talos
+bakes `pti=on` into every image, and since Linux 6.17 an explicit `pti=on` outranks
+`mitigations=off`, so PTI stays on even on CPUs carrying no Meltdown bug. Negating it is
+not available either: Talos enforces `pti=on` and `slab_nomerge` as KSPP requirements and
+a node missing either fails its `systemRequirements` boot phase.
 
 Every run logs exactly what it applied; nothing here happens silently.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -45218,6 +45218,15 @@ const DEFAULT_PROFILE = "ephemeral";
 // kernel-config default rather than a plain cmdline arg, and Image Factory does not
 // guarantee arg order (siderolabs/talos#11310), so a bare init_on_alloc=0 can lose to
 // the baked-in default. Stripping it first with -init_on_alloc makes the override stick.
+//
+// mitigations=off does not cover page-table isolation, and cannot be made to. Talos
+// bakes pti=on into every image, and since Linux 6.17 an explicit value wins:
+// pti_check_boottime_disable() consults the attack-vector table mitigations=off clears
+// only while pti_mode is PTI_AUTO, so pti=on still reaches setup_force_cpu_cap() and PTI
+// stays on even where the CPU carries no Meltdown bug. Stripping it is not an option
+// either: pkg/kernel/kspp enforces slab_nomerge and pti=on by exact value, and a node
+// missing either fails the systemRequirements phase and never boots. init_on_alloc is
+// overridable here precisely because Talos left it out of that list.
 const KERNEL_ARGS = [
   "talos.dashboard.disabled=1",
   "talos.auditd.disabled=1",
@@ -45268,6 +45277,27 @@ const IMAGE_PULLS = {
   },
 };
 
+// etcd, the kubelet and trustd all declare timeresource.NewSyncCondition in their
+// Condition(), so none of them starts until NTP against the public pool has answered:
+// time sync is a serialization point in front of the whole bring-up, and an outbound
+// dependency that hangs the run when it is blocked. Disabling it marks time synced
+// immediately rather than skipping a check that would otherwise fail, because the
+// guest clock is the host's, seeded through the emulated RTC. Already a no-op under
+// docker, which Talos runs in container mode with sync off regardless.
+const TIME_SYNC = {
+  name: "NTP time sync disabled",
+  patch: { machine: { time: { disabled: true } } },
+};
+
+// talosctl hard-codes EnableClusterDiscovery, and its qemu subcommand exposes no flag
+// to turn it off, so every throwaway cluster registers its nodes as affiliates with the
+// public discovery service at discovery.talos.dev. Nothing here needs it: the nodes sit
+// on a local bridge at addresses the provisioner assigned, and KubeSpan is off.
+const DISCOVERY = {
+  name: "cluster discovery service off",
+  patch: { cluster: { discovery: { enabled: false } } },
+};
+
 // talosctl never sets machine.install.image, so nodes come up on the generic
 // installer. On the first `talosctl upgrade` that silently drops every extension the
 // schematic baked in. Only meaningful when a schematic is in play.
@@ -45316,8 +45346,10 @@ function profileKernelArgs(profile, provider = DEFAULT_PROVIDER) {
 function profilePatches(profile, { hasSchematic = false } = {}) {
   if (profile !== "ephemeral") return emptyPatches();
 
+  const cluster = [KUBELET_GC, IMAGE_PULLS, TIME_SYNC, DISCOVERY];
+
   return {
-    cluster: hasSchematic ? [KUBELET_GC, IMAGE_PULLS, INSTALL_IMAGE] : [KUBELET_GC, IMAGE_PULLS],
+    cluster: hasSchematic ? [...cluster, INSTALL_IMAGE] : cluster,
     controlplanes: [ETCD_FSYNC, AUDIT_POLICY],
     workers: [],
   };

--- a/src/profile.js
+++ b/src/profile.js
@@ -20,6 +20,15 @@ export const DEFAULT_PROFILE = "ephemeral";
 // kernel-config default rather than a plain cmdline arg, and Image Factory does not
 // guarantee arg order (siderolabs/talos#11310), so a bare init_on_alloc=0 can lose to
 // the baked-in default. Stripping it first with -init_on_alloc makes the override stick.
+//
+// mitigations=off does not cover page-table isolation, and cannot be made to. Talos
+// bakes pti=on into every image, and since Linux 6.17 an explicit value wins:
+// pti_check_boottime_disable() consults the attack-vector table mitigations=off clears
+// only while pti_mode is PTI_AUTO, so pti=on still reaches setup_force_cpu_cap() and PTI
+// stays on even where the CPU carries no Meltdown bug. Stripping it is not an option
+// either: pkg/kernel/kspp enforces slab_nomerge and pti=on by exact value, and a node
+// missing either fails the systemRequirements phase and never boots. init_on_alloc is
+// overridable here precisely because Talos left it out of that list.
 const KERNEL_ARGS = [
   "talos.dashboard.disabled=1",
   "talos.auditd.disabled=1",
@@ -70,6 +79,27 @@ const IMAGE_PULLS = {
   },
 };
 
+// etcd, the kubelet and trustd all declare timeresource.NewSyncCondition in their
+// Condition(), so none of them starts until NTP against the public pool has answered:
+// time sync is a serialization point in front of the whole bring-up, and an outbound
+// dependency that hangs the run when it is blocked. Disabling it marks time synced
+// immediately rather than skipping a check that would otherwise fail, because the
+// guest clock is the host's, seeded through the emulated RTC. Already a no-op under
+// docker, which Talos runs in container mode with sync off regardless.
+const TIME_SYNC = {
+  name: "NTP time sync disabled",
+  patch: { machine: { time: { disabled: true } } },
+};
+
+// talosctl hard-codes EnableClusterDiscovery, and its qemu subcommand exposes no flag
+// to turn it off, so every throwaway cluster registers its nodes as affiliates with the
+// public discovery service at discovery.talos.dev. Nothing here needs it: the nodes sit
+// on a local bridge at addresses the provisioner assigned, and KubeSpan is off.
+const DISCOVERY = {
+  name: "cluster discovery service off",
+  patch: { cluster: { discovery: { enabled: false } } },
+};
+
 // talosctl never sets machine.install.image, so nodes come up on the generic
 // installer. On the first `talosctl upgrade` that silently drops every extension the
 // schematic baked in. Only meaningful when a schematic is in play.
@@ -118,8 +148,10 @@ export function profileKernelArgs(profile, provider = DEFAULT_PROVIDER) {
 export function profilePatches(profile, { hasSchematic = false } = {}) {
   if (profile !== "ephemeral") return emptyPatches();
 
+  const cluster = [KUBELET_GC, IMAGE_PULLS, TIME_SYNC, DISCOVERY];
+
   return {
-    cluster: hasSchematic ? [KUBELET_GC, IMAGE_PULLS, INSTALL_IMAGE] : [KUBELET_GC, IMAGE_PULLS],
+    cluster: hasSchematic ? [...cluster, INSTALL_IMAGE] : cluster,
     controlplanes: [ETCD_FSYNC, AUDIT_POLICY],
     workers: [],
   };

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -38,10 +38,28 @@ describe("profile", () => {
     ]);
   });
 
+  // Talos enforces these two by exact value in pkg/kernel/kspp and refuses to finish the
+  // systemRequirements phase without them, so negating either bricks the node at boot.
+  // Verified the hard way: a node booted without them logs "KSPP kernel parameter ... is
+  // required" and the create times out waiting for an API that never comes up.
+  it("never negates a KSPP-enforced kernel parameter", () => {
+    const args = profileKernelArgs("ephemeral");
+    assert.ok(!args.includes("-pti"));
+    assert.ok(!args.includes("-slab_nomerge"));
+  });
+
   it("turns on bounded parallel image pulls", () => {
     const cluster = JSON.stringify(profilePatches("ephemeral").cluster);
     assert.match(cluster, /"serializeImagePulls":false/);
     assert.match(cluster, /"maxParallelImagePulls":3/);
+  });
+
+  // Both are valid in a worker's cluster/machine section as well as a control plane's,
+  // so they ride the all-node patch rather than being split per role.
+  it("turns off time sync and cluster discovery on every node", () => {
+    const cluster = JSON.stringify(profilePatches("ephemeral").cluster);
+    assert.match(cluster, /"time":\{"disabled":true\}/);
+    assert.match(cluster, /"discovery":\{"enabled":false\}/);
   });
 
   it("puts etcd and audit settings on control planes only", () => {
@@ -96,7 +114,9 @@ describe("profile", () => {
     assert.match(lines.join("\n"), /kubelet/);
     assert.match(lines.join("\n"), /parallel image pulls/);
     assert.match(lines.join("\n"), /etcd/);
-    assert.equal(lines.length, 6);
+    assert.match(lines.join("\n"), /time sync/);
+    assert.match(lines.join("\n"), /discovery/);
+    assert.equal(lines.length, 8);
   });
 });
 


### PR DESCRIPTION
Two outbound dependencies a throwaway CI cluster has no use for, one of which can hang a run outright.

### `machine.time.disabled: true`

`etcd`, the kubelet and `trustd` all declare `timeresource.NewSyncCondition` in their `Condition()`, so none of them starts until NTP answers. `bootTimeout` defaults to **infinity**, and the sync controller disables its timeout when the value is zero, so a runner that blocks outbound UDP/123 never boots the cluster at all: it waits until the job times out. Disabling the service marks time synced immediately rather than skipping a check that would fail, and the guest clock is the host's through the emulated RTC either way. Already a no-op under the docker provider, which Talos runs in container mode with sync off regardless.

### `cluster.discovery.enabled: false`

`talosctl` hard-codes `EnableClusterDiscovery: true` and its qemu subcommand exposes no flag to turn it off, so every ephemeral cluster registers its nodes as affiliates with the public service at `discovery.talos.dev`. Nothing local needs it: the nodes sit on a bridge at addresses the provisioner assigned, and KubeSpan is off.

## Measurements

Four create/destroy cycles each way on a KVM host, 1 control plane + 1 worker:

| | CP uptime at ready | create | affiliates | syncDisabled |
|---|---|---|---|---|
| before | 125.3 / 125.4 / 147.5 / 151.8 | 228-266s | 2 | false |
| after | 131.4 / 144.4 / 125.3 / 148.8 | 238-259s | 0 | true |

**Neither change makes bring-up faster.** Medians are 136s vs 138s and image pulls dominate. Isolating the time-sync gate from that noise via node dmesg shows why: on the baseline NTP finished *before* the services waiting on it even started.

```
11:11:44.100  adjusting time (jump) by 1.267s via 162.159.200.1
11:11:47.613  service[etcd](Waiting): ... "cri" to be "up", time sync, network, etcd spec
11:11:48.631  service[etcd](Waiting): Waiting for service "cri" to be "up"
```

The gate clears in ~1.0s with the patch and ~1.0s without it. The win here is the removed dependency, not the wall-clock, which is the same trade as the kubelet GC thresholds already in the profile.

Both patches were checked against `talosctl machineconfig patch` + `talosctl validate` on generated controlplane *and* worker configs before being put on the all-node patch, and confirmed live on a real cluster (`syncDisabled=true`, affiliates `2 → 0`).

## What is not here, and why

Two further wins looked real on paper and turned out to be unreachable. Both are now recorded in the profile comments, with a test guarding against reintroducing them.

`mitigations=off` does not cover page-table isolation and cannot be made to. Talos bakes `pti=on` into every image, and since Linux 6.17 `pti_check_boottime_disable()` consults the attack-vector table that `mitigations=off` clears only while `pti_mode` is `PTI_AUTO`, so an explicit `pti=on` still reaches `setup_force_cpu_cap()`. Confirmed on a live node: `MELTDOWN Not affected`, cpuinfo `pti` flag set, dmesg `Kernel/User page tables isolation: force enabled on command line.` PTI runs on runners that carry no Meltdown bug.

Negating it is not available either, and neither is `slab_nomerge`. `pkg/kernel/kspp` enforces both by exact value, and a node missing either dies in its `systemRequirements` phase before the machine config is ever loaded:

```
[talos] task enforceKSPPRequirements (1/1): failed: 2 errors occurred:
 * KSPP kernel parameter slab_nomerge is required
 * KSPP kernel parameter pti is required
[talos] initialize sequence: failed
```

There is no escape hatch: the only branch skipping that task is `ModeContainer`, `pti=off` fails the same exact-value check, and the enforcement runs before `LoadConfig`. Talos deliberately removed `init_on_alloc` from that list "so they can be overridden via installer extra args in case of severe performance issues", which is why the profile's existing `-init_on_alloc` works and these two never will. Verified identical on 1.14.0-beta.0.

## Test plan

- [x] `mise run test` (118 pass)
- [x] `mise run lint`, `mise run build` (dist committed in step)
- [x] 8 real qemu create/destroy cycles on a KVM host
- [x] both patches validated on generated controlplane and worker configs