### PR TITLE
chore(renovate): group the Node toolchain and engines bumps

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -14,7 +14,7 @@
       minimumGroupSize: 2,
     },
     {
-      description: "Update the mise toolchain and the package.json engines floor together, on the major that matches the action runtime",
+      description: "Update the mise toolchain and the package.json engines floor together",
       matchManagers: ["mise", "npm"],
       matchPackageNames: ["node"],
       groupName: "Node Group",

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -14,9 +14,11 @@
       minimumGroupSize: 2,
     },
     {
-      description: "Keep the Node toolchain on the major that matches the action runtime",
-      matchManagers: ["mise"],
+      description: "Update the mise toolchain and the package.json engines floor together, on the major that matches the action runtime",
+      matchManagers: ["mise", "npm"],
       matchPackageNames: ["node"],
+      groupName: "Node Group",
+      minimumGroupSize: 2,
       allowedVersions: "<25",
     },
   ],


### PR DESCRIPTION
The mise toolchain pin (`.mise/config.toml`) and the `engines.node` floor in `package.json` track the same Node release, so every patch bump opens two PRs, e.g. #34 and #35 for 24.18.1.

Fold the npm manager into the existing Node rule and give it a `groupName`, so both land in a single "Node Group" PR. The `allowedVersions: "<25"` ceiling now covers `engines.node` too, which keeps the floor from advancing past the `using: node24` action runtime.

`minimumGroupSize: 2` matches the Talos Group rule: if only one manager has an update pending, it still gets its own PR rather than a group of one.

Validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFDZ4hGTR7cSjBWs7ysdkv