### PR TITLE
feat!: drive the qemu provider through talosctl cluster create dev

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
       ${{ github.event_name != 'push'
       && !(startsWith(github.head_ref, 'release-please--')
       && github.event.pull_request.head.repo.full_name == github.repository) }}
-    name: E2E (${{ matrix.example }})
+    name: E2E (${{ matrix.name || matrix.example }})
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -101,6 +101,18 @@ jobs:
           - example: maintenance
             nodes: 1
             maintenance: true
+          # The next Talos release, before consumers can hit it. `cluster create
+          # dev` promises no flag stability between releases, so this leg pays that
+          # tax up front: the dev dialect and the next config contract are proven
+          # here weeks before the release ships. minimal.yaml pins no talos-version,
+          # so the action's talosctl-version fallback drives every Factory URL to
+          # this version too.
+          # renovate: datasource=github-releases depName=siderolabs/talos versioning=semver
+          - example: minimal
+            name: talosctl-next
+            nodes: 1
+            talos-version: v1.14.0-beta.1
+            cache: true
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -110,6 +122,8 @@ jobs:
       # Deliberately a plain binary on PATH rather than a version manager: the
       # action must not depend on how talosctl got there.
       - name: Install talosctl
+        env:
+          TALOS_VERSION: ${{ matrix.talos-version || env.TALOS_VERSION }}
         run: |
           curl -sfL "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-amd64" -o talosctl
           sudo install -m 0755 talosctl /usr/local/bin/talosctl

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ permissions:
 
 env:
   # renovate: datasource=github-releases depName=siderolabs/talos
-  TALOS_VERSION: v1.13.7
+  TALOS_VERSION: v1.14.0-beta.1
 
 jobs:
   bundle-freshness:
@@ -64,9 +64,8 @@ jobs:
       ${{ github.event_name != 'push'
       && !(startsWith(github.head_ref, 'release-please--')
       && github.event.pull_request.head.repo.full_name == github.repository) }}
-    name: E2E (${{ matrix.name || matrix.example }})
+    name: E2E (${{ matrix.example }})
     runs-on: ubuntu-24.04
-    continue-on-error: ${{ matrix.experimental || false }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -102,23 +101,6 @@ jobs:
           - example: maintenance
             nodes: 1
             maintenance: true
-          # The next Talos release, before consumers can hit it. `cluster create
-          # dev` promises no flag stability between releases, so this leg pays that
-          # tax up front: the dev dialect and the next config contract are proven
-          # here weeks before the release ships. minimal.yaml pins no talos-version,
-          # so the action's talosctl-version fallback drives every Factory URL to
-          # this version too. A prerelease pin lets Renovate offer prereleases; once
-          # it converges on a final release, re-point it at the next alpha by hand.
-          - example: minimal
-            name: talosctl-next
-            nodes: 1
-            # renovate: datasource=github-releases depName=siderolabs/talos
-            talos-version: v1.14.0-beta.1
-            cache: true
-            # Non-blocking until #46 (profile patches vs 1.14 typed config
-            # documents) is fixed; the drift stays visible without gating merges
-            # on an upstream beta.
-            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -128,8 +110,6 @@ jobs:
       # Deliberately a plain binary on PATH rather than a version manager: the
       # action must not depend on how talosctl got there.
       - name: Install talosctl
-        env:
-          TALOS_VERSION: ${{ matrix.talos-version || env.TALOS_VERSION }}
         run: |
           curl -sfL "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-amd64" -o talosctl
           sudo install -m 0755 talosctl /usr/local/bin/talosctl

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,11 +106,12 @@ jobs:
           # tax up front: the dev dialect and the next config contract are proven
           # here weeks before the release ships. minimal.yaml pins no talos-version,
           # so the action's talosctl-version fallback drives every Factory URL to
-          # this version too.
-          # renovate: datasource=github-releases depName=siderolabs/talos versioning=semver
+          # this version too. A prerelease pin lets Renovate offer prereleases; once
+          # it converges on a final release, re-point it at the next alpha by hand.
           - example: minimal
             name: talosctl-next
             nodes: 1
+            # renovate: datasource=github-releases depName=siderolabs/talos
             talos-version: v1.14.0-beta.1
             cache: true
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,7 @@ jobs:
       && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: E2E (${{ matrix.name || matrix.example }})
     runs-on: ubuntu-24.04
+    continue-on-error: ${{ matrix.experimental || false }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -114,6 +115,10 @@ jobs:
             # renovate: datasource=github-releases depName=siderolabs/talos
             talos-version: v1.14.0-beta.1
             cache: true
+            # Non-blocking until #46 (profile patches vs 1.14 typed config
+            # documents) is fixed; the drift stays visible without gating merges
+            # on an upstream beta.
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -22,7 +22,7 @@ yq = "4.53.3"
 # Only used by `mise run e2e` to exercise the action against a real cluster on a
 # KVM-capable host. Consumers pin their own talosctl; the action resolves whatever
 # the caller provides.
-talosctl = "1.13.7"
+talosctl = "1.14.0-beta.1"
 
 [tasks.install]
 description = "Install npm dependencies from the lockfile"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -147,6 +147,7 @@ checksum = "sha256:df224555a083b918e46260cc969838501b9f9a87140c1195e5b9597b56d5d
 url = "https://nodejs.org/dist/v24.18.1/node-v24.18.1-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
+checksum = "sha256:ae1b6457edb875fd98130b37c853e51a53ac0cc40850ecccd490b61c5a3558fa"
 url = "https://unofficial-builds.nodejs.org/download/release/v24.18.1/node-v24.18.1-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
@@ -154,6 +155,7 @@ checksum = "sha256:9f5eb6ac21845a66c493c91a253b1da32fd684e89e9b7202d4936982336be
 url = "https://nodejs.org/dist/v24.18.1/node-v24.18.1-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
+checksum = "sha256:696979caef92505ad7566a3674ca9a93d8558e282f34e7899181c0321821ae5f"
 url = "https://unofficial-builds.nodejs.org/download/release/v24.18.1/node-v24.18.1-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]
@@ -234,49 +236,49 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056944"
 
 [[tools.talosctl]]
-version = "1.13.7"
+version = "1.14.0-beta.1"
 backend = "aqua:siderolabs/talos"
 
 [tools.talosctl."platforms.linux-arm64"]
-checksum = "sha256:756ef525dbff50bcaa67750fce70efbef2899ec87c87468914a8390ce292b1d4"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.7/talosctl-linux-arm64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/484644288"
+checksum = "sha256:9d546ccdc0f2df58234f94bb988d1c8d1a512017819c1a6cc4d60647ad810e2f"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0-beta.1/talosctl-linux-arm64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/496642705"
 provenance = "cosign"
 
 [tools.talosctl."platforms.linux-arm64-musl"]
-checksum = "sha256:756ef525dbff50bcaa67750fce70efbef2899ec87c87468914a8390ce292b1d4"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.7/talosctl-linux-arm64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/484644288"
+checksum = "sha256:9d546ccdc0f2df58234f94bb988d1c8d1a512017819c1a6cc4d60647ad810e2f"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0-beta.1/talosctl-linux-arm64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/496642705"
 provenance = "cosign"
 
 [tools.talosctl."platforms.linux-x64"]
-checksum = "sha256:97d08e5584e56114659f131e95e227910d1f3b427d26360dca2af3ed821b71f8"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.7/talosctl-linux-amd64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/484644296"
+checksum = "sha256:367842b0ea4db95756ced4681808b0a8f4ccc637fff1344c9eb1b5d292bdcd31"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0-beta.1/talosctl-linux-amd64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/496642710"
 provenance = "cosign"
 
 [tools.talosctl."platforms.linux-x64-musl"]
-checksum = "sha256:97d08e5584e56114659f131e95e227910d1f3b427d26360dca2af3ed821b71f8"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.7/talosctl-linux-amd64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/484644296"
+checksum = "sha256:367842b0ea4db95756ced4681808b0a8f4ccc637fff1344c9eb1b5d292bdcd31"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0-beta.1/talosctl-linux-amd64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/496642710"
 provenance = "cosign"
 
 [tools.talosctl."platforms.macos-arm64"]
-checksum = "sha256:8965b026f416a25147b99530721c25fc2616c4fa655480673bcb63eb7f0de331"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.7/talosctl-darwin-arm64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/484644319"
+checksum = "sha256:ded9121c64dad4dd49947282a5d751daf5c6c53c9ba79232398f866c3f41daa2"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0-beta.1/talosctl-darwin-arm64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/496642692"
 provenance = "cosign"
 
 [tools.talosctl."platforms.macos-x64"]
-checksum = "sha256:0e4b75ee78da180103aceda6da9c906bd2cba48cd7c7c2e9049776445beab688"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.7/talosctl-darwin-amd64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/484644291"
+checksum = "sha256:14ef60180a65e4f0aff051ce7447e3cf3e1227a9b259b19fa051996c607cd264"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0-beta.1/talosctl-darwin-amd64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/496642693"
 provenance = "cosign"
 
 [tools.talosctl."platforms.windows-x64"]
-checksum = "sha256:a42fb71c4f8d5b6148ac996b109bce708986e44354910c3a533942342536e958"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.7/talosctl-windows-amd64.exe"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/484644290"
+checksum = "sha256:a30133ac68e34269afce89e93ef18b2c961af7fa70e909c2149fdb6236366704"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0-beta.1/talosctl-windows-amd64.exe"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/496642691"
 provenance = "cosign"
 
 [[tools.yq]]

--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ length limit that is not obvious until it bites), so it lives here once.
 | Boots in           | minutes                         | seconds                       |
 
 Use `qemu` when the test needs a real kernel, real disks, or a real upgrade; `docker`
-when it only needs a Kubernetes API to talk to. Both need `talosctl` **v1.13 or
-newer** on `PATH`.
+when it only needs a Kubernetes API to talk to. Both need `talosctl` **v1.14 or
+newer** on `PATH`, and the clusters run Talos 1.14+: the ephemeral profile is written
+as the typed config documents that 1.14 configs use, which older nodes reject as
+unknown. Repos on older Talos should pin an older release of this action rather than
+upgrade.
 
 The docker provider maps onto `talosctl cluster create docker`. The qemu provider is
 driven through **`talosctl cluster create dev`**: upstream froze the qemu
@@ -75,7 +78,7 @@ action update. Check the release notes before jumping a talosctl minor.
 The action provisions the cluster and nothing else: it does not install packages or
 touch the host's swap. That keeps it working on any distribution and keeps host
 mutation in your workflow, where you can see it. Both providers need `talosctl`
-**v1.13 or newer** on `PATH`.
+**v1.14 or newer** on `PATH`.
 
 ### qemu
 
@@ -83,7 +86,7 @@ mutation in your workflow, where you can see it. Both providers need `talosctl`
 - name: Install talosctl
   env:
     # renovate: datasource=github-releases depName=siderolabs/talos
-    TALOS_VERSION: v1.13.7
+    TALOS_VERSION: v1.14.0-beta.1
   run: |
     curl -sfL "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-amd64" -o talosctl
     sudo install -m 0755 talosctl /usr/local/bin/talosctl
@@ -116,7 +119,7 @@ runners and the runner user is already in the `docker` group, so no install is n
 - name: Install talosctl
   env:
     # renovate: datasource=github-releases depName=siderolabs/talos
-    TALOS_VERSION: v1.13.7
+    TALOS_VERSION: v1.14.0-beta.1
   run: |
     curl -sfL "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-amd64" -o talosctl
     sudo install -m 0755 talosctl /usr/local/bin/talosctl
@@ -229,18 +232,18 @@ A cluster that lives for one CI run wants a set of settings that a real cluster 
 not. `spec.profile` defaults to `ephemeral` and applies them, so a spec is only what
 makes your cluster different:
 
-| Setting                                                           | Why                                                         |
-| ----------------------------------------------------------------- | ----------------------------------------------------------- |
-| `talos.dashboard.disabled=1`                                      | The console dashboard redraws for nobody to watch.          |
-| `talos.auditd.disabled=1`                                         | Kernel audit events nothing reads.                          |
-| `mitigations=off`                                                 | Side-channel mitigations cost cycles in a throwaway guest.  |
-| `init_on_alloc=0`                                                 | Zeroing every allocation costs cycles in a throwaway guest. |
-| kubelet `imageGCHighThresholdPercent` + `evictionHard` at zero    | Stops image GC and pod eviction from reading as flakes.     |
-| kubelet `serializeImagePulls: false` (`maxParallelImagePulls: 3`) | Pulls images in parallel, the slowest part of a cold start. |
-| `machine.time.disabled`                                           | NTP sync gates etcd, the kubelet and trustd on every boot.  |
-| `cluster.discovery.enabled: false`                                | Nothing local needs the public discovery service.           |
-| etcd `unsafe-no-fsync`                                            | Durability for I/O, on a cluster about to be deleted.       |
-| apiserver `auditPolicy: None`                                     | Talos logs every request to disk by default.                |
+| Setting                                                         | Why                                                         |
+| --------------------------------------------------------------- | ----------------------------------------------------------- |
+| `talos.dashboard.disabled=1`                                    | The console dashboard redraws for nobody to watch.          |
+| `talos.auditd.disabled=1`                                       | Kernel audit events nothing reads.                          |
+| `mitigations=off`                                               | Side-channel mitigations cost cycles in a throwaway guest.  |
+| `init_on_alloc=0`                                               | Zeroing every allocation costs cycles in a throwaway guest. |
+| `KubeletConfig` GC + eviction thresholds at zero                | Stops image GC and pod eviction from reading as flakes.     |
+| `KubeletConfig` `serializeImagePulls: false` (3 parallel pulls) | Pulls images in parallel, the slowest part of a cold start. |
+| `machine.time.disabled`                                         | NTP sync gates etcd, the kubelet and trustd on every boot.  |
+| discovery service off                                           | Nothing local needs the public discovery service.           |
+| etcd `unsafe-no-fsync`                                          | Durability for I/O, on a cluster about to be deleted.       |
+| `KubeAuditPolicyConfig` rules: `None`                           | Talos logs every request to disk by default.                |
 
 `mitigations=off` does not cover page-table isolation, and nothing can make it. Talos
 bakes `pti=on` into every image, and since Linux 6.17 an explicit `pti=on` outranks
@@ -268,6 +271,15 @@ spec:
             extraArgs:
               unsafe-no-fsync: "false" # keep the rest of the profile
 ```
+
+The kubelet and audit-policy settings are the 1.14 **typed documents**
+(`KubeletConfig`, `KubeAuditPolicyConfig`) rather than v1alpha1 sections, because a
+1.14 config that sets the same area in both is rejected; overriding those means
+patching the same document kind. Patching `.machine.kubelet` or
+`.cluster.apiServer` yourself hits the same rejection. Discovery is not a patch at
+all: the qemu provider turns it off at generation time, and the docker provider
+deletes the generated `DiscoveryServiceConfig` document; wanting it back on means
+adding that document via config-patches.
 
 **The install image** is pinned by the action itself, not by the profile: it always
 passes `--install-image` pointing at the Factory installer for the schematic in play

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ metadata:
   name: e2e-3cp-0w
 spec:
   qemu:
-    talos-version: v1.13.6
+    talos-version: v1.14.0-beta.1
   controlplanes:
     count: 3
   workers:

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ length limit that is not obvious until it bites), so it lives here once.
 
 ## Providers
 
-`spec.provider` picks the `talosctl cluster create` subcommand. They are not
-interchangeable, and the differences are talosctl's, not this action's:
+`spec.provider` picks how the nodes run. They are not interchangeable:
 
 |                    | `qemu` (default)                | `docker`                      |
 | ------------------ | ------------------------------- | ----------------------------- |
@@ -58,10 +57,18 @@ interchangeable, and the differences are talosctl's, not this action's:
 
 Use `qemu` when the test needs a real kernel, real disks, or a real upgrade; `docker`
 when it only needs a Kubernetes API to talk to. Both need `talosctl` **v1.13 or
-newer** on `PATH`. v1.12 introduced these subcommands, but the action also emits
-`--image-factory-auth` and accepts `:tag=` / `:serial=` disk parameters, neither of
-which v1.12 understands; it checks the version and says so rather than letting cobra
-report an unknown flag.
+newer** on `PATH`.
+
+The docker provider maps onto `talosctl cluster create docker`. The qemu provider is
+driven through **`talosctl cluster create dev`**: upstream froze the qemu
+subcommand's flag surface and points anyone needing the full set at `dev`, so the
+action pins the behavior the qemu subcommand had — the same Image Factory boot media
+(as explicit URLs), the same boot-to-maintenance-then-apply-over-the-API lifecycle,
+the same schematic-pinned install image — through explicit flags, and layers the
+extra capabilities only `dev` exposes on top over time. `dev` makes no
+interface-stability promise between talosctl releases; this action's e2e pins the
+tested version, and a talosctl release the action has not caught up with may need an
+action update. Check the release notes before jumping a talosctl minor.
 
 ## Runner setup
 
@@ -125,7 +132,7 @@ runners and the runner user is already in the `docker` group, so no install is n
 
 ### About sudo
 
-The action shells out to `sudo` for exactly one thing: `talosctl cluster create qemu`.
+The action shells out to `sudo` for exactly one thing: `talosctl cluster create dev`.
 That is not a choice. The QEMU provisioner's _first_ preflight check is
 `os.Geteuid() != 0`, and its own error recommends `sudo -E`:
 
@@ -164,45 +171,46 @@ container image, and no boot assets are involved.
 flag. A field the spec omits is not passed, so it keeps talosctl's own default rather
 than one this action invents and then has to track across Talos releases.
 
-Shared by both providers:
+Shared by both providers (the flag column shows the qemu provider's dev dialect;
+docker keeps its own names for a few of them):
 
-| Field                               | Flag                                   |
-| ----------------------------------- | -------------------------------------- |
-| `metadata.name`                     | `--name`                               |
-| `spec.provider`                     | selects the subcommand                 |
-| `spec.profile`                      | (see below)                            |
-| `spec.kubernetes-version`           | `--kubernetes-version`                 |
-| `spec.controlplanes.count`          | `--controlplanes` (qemu only)          |
-| `spec.controlplanes.cpus`           | `--cpus-controlplanes`                 |
-| `spec.controlplanes.memory`         | `--memory-controlplanes`               |
-| `spec.workers.count`                | `--workers`                            |
-| `spec.workers.cpus`                 | `--cpus-workers`                       |
-| `spec.workers.memory`               | `--memory-workers`                     |
-| `spec.network.cidr`                 | `--cidr` on qemu, `--subnet` on docker |
-| `spec.network.mtu`                  | `--mtu`                                |
-| `spec.config-patches.cluster`       | `--config-patch`                       |
-| `spec.config-patches.controlplanes` | `--config-patch-controlplanes`         |
-| `spec.config-patches.workers`       | `--config-patch-workers`               |
+| Field                               | Flag                                              |
+| ----------------------------------- | ------------------------------------------------- |
+| `metadata.name`                     | `--name`                                          |
+| `spec.provider`                     | selects the subcommand                            |
+| `spec.profile`                      | (see below)                                       |
+| `spec.kubernetes-version`           | `--kubernetes-version`                            |
+| `spec.controlplanes.count`          | `--controlplanes` (qemu only)                     |
+| `spec.controlplanes.cpus`           | `--cpus` (docker: `--cpus-controlplanes`)         |
+| `spec.controlplanes.memory`         | `--memory` (docker: `--memory-controlplanes`)     |
+| `spec.workers.count`                | `--workers`                                       |
+| `spec.workers.cpus`                 | `--cpus-workers`                                  |
+| `spec.workers.memory`               | `--memory-workers`                                |
+| `spec.network.cidr`                 | `--cidr` on qemu, `--subnet` on docker            |
+| `spec.network.mtu`                  | `--mtu`                                           |
+| `spec.config-patches.cluster`       | `--config-patch`                                  |
+| `spec.config-patches.controlplanes` | `--config-patch-control-plane` / `-controlplanes` |
+| `spec.config-patches.workers`       | `--config-patch-worker` / `-workers`              |
 
 Provider-specific, and an error if it does not match `spec.provider`:
 
-| Field                                   | Flag                   |
-| --------------------------------------- | ---------------------- |
-| `spec.qemu.talos-version`               | `--talos-version`      |
-| `spec.qemu.disks`                       | `--disks`              |
-| `spec.qemu.schematic` / `.schematic-id` | `--schematic-id`       |
-| `spec.qemu.image-factory.url`           | `--image-factory-url`  |
-| `spec.qemu.image-factory.auth`          | `--image-factory-auth` |
-| `spec.qemu.presets`                     | `--presets`            |
-| `spec.docker.image`                     | `--image`              |
-| `spec.docker.host-ip`                   | `--host-ip`            |
-| `spec.docker.exposed-ports`             | `--exposed-ports`      |
-| `spec.docker.mounts`                    | `--mount` (repeated)   |
+| Field                                   | Becomes                                                    |
+| --------------------------------------- | ---------------------------------------------------------- |
+| `spec.qemu.talos-version`               | `--talos-version`, and the version in every Factory URL    |
+| `spec.qemu.disks`                       | `--disk` + `--extra-disks*` (see Disks)                    |
+| `spec.qemu.schematic` / `.schematic-id` | the schematic in the boot media and install-image URLs     |
+| `spec.qemu.image-factory.url`           | the base of every Factory URL the action builds            |
+| `spec.qemu.image-factory.auth`          | an authenticated pre-download into talosctl's asset cache  |
+| `spec.qemu.presets`                     | the boot media flag (`--iso-path`, `--disk-image-path`, …) |
+| `spec.docker.image`                     | `--image`                                                  |
+| `spec.docker.host-ip`                   | `--host-ip`                                                |
+| `spec.docker.exposed-ports`             | `--exposed-ports`                                          |
+| `spec.docker.mounts`                    | `--mount` (repeated)                                       |
 
-`spec.network.cidr` is one field because talosctl's `--cidr` and `--subnet` set the
-same underlying option. `spec.controlplanes.count` is the awkward one: docker never
-exposes it and always runs exactly one, so setting anything else there is rejected
-rather than silently ignored.
+`spec.network.cidr` is one field because both subcommands set the same underlying
+option. `spec.controlplanes.count` is the awkward one: docker never exposes it and
+always runs exactly one, so setting anything else there is rejected rather than
+silently ignored.
 
 `spec` is optional: a document with only `metadata.name` boots a qemu cluster on every
 talosctl default.
@@ -233,7 +241,6 @@ makes your cluster different:
 | `cluster.discovery.enabled: false`                                | Nothing local needs the public discovery service.           |
 | etcd `unsafe-no-fsync`                                            | Durability for I/O, on a cluster about to be deleted.       |
 | apiserver `auditPolicy: None`                                     | Talos logs every request to disk by default.                |
-| `machine.install.image` pinned to the schematic                   | Only when a schematic is used; see below.                   |
 
 `mitigations=off` does not cover page-table isolation, and nothing can make it. Talos
 bakes `pti=on` into every image, and since Linux 6.17 an explicit `pti=on` outranks
@@ -243,10 +250,9 @@ a node missing either fails its `systemRequirements` boot phase.
 
 Every run logs exactly what it applied; nothing here happens silently.
 
-`profile: none` applies none of it. Under the **docker provider** the kernel args and
-the install image pin are skipped, because both ride in an Image Factory schematic and
-docker boots a prebuilt image instead; the kubelet, etcd, and audit settings still
-apply.
+`profile: none` applies none of it. Under the **docker provider** the kernel args are
+skipped, because they ride in an Image Factory schematic and docker boots a prebuilt
+image instead; the kubelet, etcd, and audit settings still apply.
 
 **Overriding one setting** does not mean giving up the rest. The profile's settings
 are ordinary config patches emitted _before_ yours, and talosctl applies patches in
@@ -263,13 +269,12 @@ spec:
               unsafe-no-fsync: "false" # keep the rest of the profile
 ```
 
-**The install image pin** is the one that is easy to miss. `talosctl` never sets
-`machine.install.image`, so nodes boot from your schematic but come up on the generic
-installer, and the first `talosctl upgrade` silently drops every extension the
-schematic baked in. Whenever a schematic is in play, the profile pins the install
-image to the matching Factory image. Because it needs a Talos version, and a spec need
-not name one, the action falls back to the version `talosctl` would have chosen for
-itself.
+**The install image** is pinned by the action itself, not by the profile: it always
+passes `--install-image` pointing at the Factory installer for the schematic in play
+(or the empty one), because the dev subcommand's default is the generic installer,
+which would silently drop every schematic extension on the first `talosctl upgrade`.
+Because the pin needs a Talos version, and a spec need not name one, the action falls
+back to the version `talosctl` would have chosen for itself.
 
 **Kernel args are the exception to the override rule.** They live in the Image Factory
 schematic rather than in a config patch, so no later patch can override them. They
@@ -305,6 +310,11 @@ spec:
       - virtio:10GiB # every node
       - virtio:20GiB # workers only
 ```
+
+Two constraints come from the dev subcommand's count-based disk flags, and violating
+either is a validation error rather than a silent reshaping: the **first disk must be
+virtio** (and carries no `tag=`/`serial=`), and the **extra disks must all be the same
+size**. Extras keep per-disk drivers, tags, and serials.
 
 ### Patches and schematics
 
@@ -384,13 +394,14 @@ spec:
             - siderolabs/drbd
 ```
 
-Two consumers, because there are two calls: the action registers the schematic over
-HTTP itself and then hands the same settings to `talosctl`, which fetches the boot
-media. A URL with a path is kept intact, so `/image-factory` above is registered at
-`/image-factory/schematics`. `auth` is sent as HTTP Basic on the action's own request
-and passed through as `--image-factory-auth`; it is registered as a secret, so the
-runner masks it in the command line the log echoes. Keep it in a GitHub secret rather
-than committing it, and note it needs talosctl v1.13 or newer.
+The action is the only consumer: it registers the schematic over HTTP, builds the
+boot media URLs against the same base, and with `auth` set it downloads the media
+itself — HTTP Basic in headers, never in a command line — into the URL-keyed cache
+`talosctl` checks before downloading anything. A URL with a path is kept intact, so
+`/image-factory` above is registered at `/image-factory/schematics`. The one
+host-shaped exception is the install image, which is an OCI reference and therefore
+uses the factory URL's host only. Keep `auth` in a GitHub secret rather than
+committing it.
 
 ### Maintenance mode
 
@@ -577,10 +588,11 @@ characters by the UNIX socket limit. A name carrying `github.run_id` overflows i
 QEMU's error names the socket rather than the name that caused it. The action checks
 this up front and tells you how many characters you have.
 
-**IPv6 is not available.** `talosctl cluster create qemu` has no `--ipv6` flag; it
-exists only on `cluster create dev`, which cannot use Image Factory schematics. For
-IPv6 inside the cluster, patch `cluster.network.podSubnets` / `serviceSubnets` under
-`spec.config-patches`. Setting `spec.network.ipv6` is a validation error that says so.
+**IPv6 is not exposed yet.** The dev subcommand the action now drives does have
+`--ipv6`, so this is a planned spec field rather than an upstream limitation. Until
+then, for IPv6 inside the cluster, patch `cluster.network.podSubnets` /
+`serviceSubnets` under `spec.config-patches`. Setting `spec.network.ipv6` is a
+validation error that says so.
 
 **One cluster per CIDR per host.** The provisioner puts the bridge on the first
 address of the CIDR, so two clusters sharing a CIDR share a bridge and its tap

--- a/dist/index.js
+++ b/dist/index.js
@@ -90311,6 +90311,44 @@ function bootAssetsKey({
   return `talos-boot-assets-${arch}-${talosVersion}-${fingerprint}`;
 }
 
+/**
+ * The path talosctl's downloadBootAssets would cache a URL at: the full URL with
+ * '/' and ':' flattened to '-', inside the cache directory it stats before
+ * downloading.
+ */
+const assetCachePath = (url) =>
+  path$1.join(bootAssetsDir(), url.replaceAll("/", "-").replaceAll(":", "-"));
+
+/**
+ * Pre-download boot assets into talosctl's own cache, authenticating with HTTP
+ * Basic. The dev subcommand has no --image-factory-auth, and credentials embedded
+ * in the URL would ride in argv; fetching here keeps them in headers, and
+ * talosctl's cache check makes the URL a no-op download afterwards.
+ */
+async function preseedBootAssets(urls, auth) {
+  fs$1.mkdirSync(bootAssetsDir(), { recursive: true });
+
+  for (const url of urls) {
+    const destination = assetCachePath(url);
+    if (fs$1.existsSync(destination)) continue;
+
+    info(`Fetching ${url} into the boot asset cache`);
+
+    const response = await fetch(url, {
+      headers: { authorization: `Basic ${Buffer.from(auth).toString("base64")}` },
+    });
+    if (!response.ok) {
+      throw new Error(`could not fetch ${url}: ${response.status} ${response.statusText}`);
+    }
+
+    // Written via a temp name so a failure part-way never leaves a file that
+    // talosctl's existence check would mistake for a complete download.
+    const partial = `${destination}.partial`;
+    fs$1.writeFileSync(partial, Buffer.from(await response.arrayBuffer()));
+    fs$1.renameSync(partial, destination);
+  }
+}
+
 /** Restore the boot asset directory; returns the hit key, or undefined on a miss. */
 async function restoreBootAssets(key) {
   if (!isFeatureAvailable()) {
@@ -90343,6 +90381,97 @@ async function saveBootAssets(key, restoredKey) {
     // have won the race to save this key.
     warning(`boot asset cache save failed: ${err.message}`);
   }
+}
+
+/**
+ * Image Factory asset references for the dev backend.
+ *
+ * `cluster create dev` takes boot media as plain paths or URLs rather than a
+ * schematic id, so the action builds the same Factory URLs the qemu subcommand's
+ * presets would have (preset/*.go in talosctl), byte for byte: the schematic id
+ * (or the well-known empty one), the Talos version, and the metal platform's
+ * asset naming.
+ */
+
+// constants.ImageFactoryEmptySchematicID: what `cluster create qemu` substitutes
+// when no schematic is given, so a spec without one boots identical media.
+const EMPTY_SCHEMATIC_ID =
+  "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba";
+
+// Node arch to Talos arch. The provisioner targets the host's own architecture.
+const ARCHES = { x64: "amd64", arm64: "arm64" };
+const talosArch = (nodeArch = process.arch) => ARCHES[nodeArch] ?? "amd64";
+
+// A relative reference resolves against the base's *directory*, so a factory URL
+// with a path but no trailing slash would silently lose that path (same rule as
+// schematic registration).
+const join = (factoryUrl, ...segments) =>
+  new URL(segments.join("/"), factoryUrl.endsWith("/") ? factoryUrl : `${factoryUrl}/`).toString();
+
+/** The boot-method preset in play: the first non-maintenance entry, iso by default. */
+const bootMethodOf = (presets) =>
+  (presets ?? []).find((preset) => preset !== "maintenance") ?? "iso";
+
+/**
+ * The dev flag and Factory URL for the spec's boot method. Mirrors talosctl's
+ * iso/iso-secureboot/pxe/disk-image presets (metal platform asset paths).
+ */
+function bootAsset({
+  presets,
+  factoryUrl = DEFAULT_FACTORY_URL,
+  schematicId,
+  talosVersion,
+  arch = talosArch(),
+}) {
+  const id = schematicId ?? EMPTY_SCHEMATIC_ID;
+  const method = bootMethodOf(presets);
+
+  switch (method) {
+    case "iso":
+      return {
+        flag: "--iso-path",
+        url: join(factoryUrl, "image", id, talosVersion, `metal-${arch}.iso`),
+        secureboot: false,
+      };
+    case "iso-secureboot":
+      return {
+        flag: "--iso-path",
+        url: join(factoryUrl, "image", id, talosVersion, `metal-${arch}-secureboot.iso`),
+        secureboot: true,
+      };
+    case "disk-image":
+      return {
+        flag: "--disk-image-path",
+        url: join(factoryUrl, "image", id, talosVersion, `metal-${arch}.raw.zst`),
+        secureboot: false,
+      };
+    case "pxe":
+      return {
+        flag: "--ipxe-boot-script",
+        url: join(factoryUrl, "pxe", id, talosVersion, `metal-${arch}`),
+        secureboot: false,
+      };
+    default:
+      throw new Error(`unknown boot-method preset '${method}'`);
+  }
+}
+
+/**
+ * The installer image reference the stable subcommand would have pinned
+ * (applyDefaultSettings in preset.go). dev defaults to the generic installer,
+ * which would drop schematic extensions on the first `talosctl upgrade`, so it
+ * is always passed explicitly via --install-image.
+ */
+function installerImage({
+  factoryUrl = DEFAULT_FACTORY_URL,
+  schematicId,
+  talosVersion,
+  secureboot = false,
+}) {
+  const host = new URL(factoryUrl).host;
+  const name = secureboot ? "metal-installer-secureboot" : "metal-installer";
+
+  return `${host}/${name}/${schematicId ?? EMPTY_SCHEMATIC_ID}:${talosVersion}`;
 }
 
 var ajv = {exports: {}};
@@ -97974,7 +98103,7 @@ var properties = {
 						minLength: 1
 					},
 					disks: {
-						description: "Disks per node, as \"driver:size\" with optional \":tag=\" / \":serial=\" parameters. Maps to a single --disks flag. The first disk goes to every node; any after it are attached to workers only.",
+						description: "Disks per node, as \"driver:size\" with optional \":tag=\" / \":serial=\" parameters. The first disk goes to every node, must be virtio, and carries no parameters; any after it are attached to workers only and must all share one size (per-disk drivers, tags, and serials are fine).",
 						type: "array",
 						minItems: 1,
 						items: {
@@ -98101,10 +98230,84 @@ const providerOf = (cluster) => cluster.spec?.provider ?? DEFAULT_PROVIDER;
 const hasMaintenancePreset = (cluster) =>
   Boolean(cluster.spec?.qemu?.presets?.includes("maintenance"));
 
+// One disk entry: driver, a size with unit, then optional :tag= / :serial= params.
+const DISK_RE = /^([a-z0-9]+):([0-9]+(?:\.[0-9]+)?)\s*([KMGT]i?B|B)?((?::[a-z]+=[^:]+)*)$/;
+
+const UNIT_MB = {
+  B: 1 / (1024 * 1024),
+  KB: 1 / 1024,
+  KiB: 1 / 1024,
+  MB: 1,
+  MiB: 1,
+  GB: 1024,
+  GiB: 1024,
+  TB: 1024 * 1024,
+  TiB: 1024 * 1024,
+};
+
+/**
+ * Map spec.qemu.disks onto `cluster create dev`'s count-based disk flags.
+ *
+ * The dev subcommand kept the legacy disk interface: one virtio primary sized in
+ * MB, plus N worker-only extra disks that share a single size but carry per-disk
+ * drivers, tags, and serials. The list syntax stays expressible with two
+ * constraints, both rejected here with the reason rather than silently mangled:
+ * the primary must be virtio, and every extra disk must be the same size.
+ */
+function translateDisks(disks) {
+  const parse = (entry, position) => {
+    const match = DISK_RE.exec(entry);
+    if (!match) throw new Error(`spec.qemu.disks[${position}]: cannot parse '${entry}'`);
+
+    const [, driver, size, unit = "MiB", params] = match;
+    const mb = Math.round(Number(size) * UNIT_MB[unit]);
+    const tag = /:tag=([^:]+)/.exec(params)?.[1] ?? "";
+    const serial = /:serial=([^:]+)/.exec(params)?.[1] ?? "";
+
+    return { driver, mb, tag, serial };
+  };
+
+  const [primary, ...extras] = disks.map(parse);
+
+  if (primary.driver !== "virtio") {
+    throw new Error(
+      `spec.qemu.disks[0]: the primary disk must be virtio; '${primary.driver}' is only ` +
+        "available for the extra worker disks",
+    );
+  }
+  if (primary.tag || primary.serial) {
+    throw new Error("spec.qemu.disks[0]: tag= and serial= are only available on extra disks");
+  }
+
+  const sizes = new Set(extras.map((disk) => disk.mb));
+  if (sizes.size > 1) {
+    throw new Error(
+      "spec.qemu.disks: extra disks must all be the same size " +
+        `(got ${[...sizes].join("MB, ")}MB); talosctl's dev interface sizes them together`,
+    );
+  }
+
+  return {
+    disk: primary.mb,
+    extraDisks: extras.length,
+    extraDisksSize: extras[0]?.mb,
+    drivers: extras.map((disk) => disk.driver),
+    tags: extras.map((disk) => disk.tag),
+    serials: extras.map((disk) => disk.serial),
+  };
+}
+
 function buildArgs(cluster, ctx = {}) {
   const spec = cluster.spec ?? {};
   const provider = providerOf(cluster);
-  const args = ["cluster", "create", provider, "--name", cluster.metadata.name];
+
+  // The qemu provider is driven through `cluster create dev`: upstream froze the
+  // qemu subcommand's flag surface and points anyone needing the full set (boot
+  // media paths, install image, network shaping) at dev. The action pins the
+  // exact behavior the qemu subcommand had — same Factory media, same
+  // maintenance-boot + API-apply lifecycle — through explicit flags.
+  const args = ["cluster", "create", provider === "qemu" ? "dev" : provider];
+  args.push("--name", cluster.metadata.name);
 
   const push = (flag, value) => {
     if (value !== undefined && value !== null) args.push(flag, String(value));
@@ -98112,39 +98315,78 @@ function buildArgs(cluster, ctx = {}) {
 
   push("--kubernetes-version", spec["kubernetes-version"] && withoutV(spec["kubernetes-version"]));
 
-  // Shared, except --controlplanes: docker never registers it and always runs exactly
-  // one, so passing it would be an unknown-flag error rather than a no-op.
-  if (provider === "qemu") push("--controlplanes", spec.controlplanes?.count);
-  push("--cpus-controlplanes", spec.controlplanes?.cpus);
-  push("--memory-controlplanes", spec.controlplanes?.memory);
-
   push("--workers", spec.workers?.count);
-  push("--cpus-workers", spec.workers?.cpus);
-  push("--memory-workers", spec.workers?.memory);
-
-  // Same underlying option, different flag name per subcommand. --mtu is shared: it
-  // is registered in getCommonUserFacingFlags and merely MarkHidden, so it is absent
-  // from `--help` but accepted by both, and docker feeds it to the bridge as
-  // com.docker.network.driver.mtu.
-  push(provider === "docker" ? "--subnet" : "--cidr", spec.network?.cidr);
-  push("--mtu", spec.network?.mtu);
 
   if (provider === "qemu") {
     const qemu = spec.qemu ?? {};
 
-    push("--talos-version", qemu["talos-version"] && withV(qemu["talos-version"]));
+    // dev renamed the control-plane resource flags; the worker ones match.
+    push("--controlplanes", spec.controlplanes?.count);
+    push("--cpus", spec.controlplanes?.cpus);
+    push("--memory", spec.controlplanes?.memory);
+    push("--cpus-workers", spec.workers?.cpus);
+    push("--memory-workers", spec.workers?.memory);
 
-    // One comma-joined flag, not repeated flags: the Disks pflag.Value replaces its
-    // accumulated list on every Set, so `--disks a --disks b` silently keeps only b.
-    if (qemu.disks?.length) push("--disks", qemu.disks.join(","));
+    push("--cidr", spec.network?.cidr);
+    push("--mtu", spec.network?.mtu);
 
-    push("--schematic-id", ctx.schematicId);
-    push("--image-factory-url", qemu["image-factory"]?.url);
-    push("--image-factory-auth", qemu["image-factory"]?.auth);
+    if (qemu.disks?.length) {
+      const disks = translateDisks(qemu.disks);
+      push("--disk", disks.disk);
+      if (disks.extraDisks > 0) {
+        push("--extra-disks", disks.extraDisks);
+        push("--extra-disks-size", disks.extraDisksSize);
+        push("--extra-disks-drivers", disks.drivers.join(","));
+        if (disks.tags.some(Boolean)) push("--extra-disks-tags", disks.tags.join(","));
+        if (disks.serials.some(Boolean)) push("--extra-disks-serials", disks.serials.join(","));
+      }
+    }
 
-    if (qemu.presets?.length) push("--presets", qemu.presets.join(","));
+    // Always passed: dev defaults to "latest", and the boot asset URLs and the
+    // install image pin below already embed the resolved version.
+    push("--talos-version", ctx.talosVersion);
+
+    // The boot media the qemu subcommand's preset would have chosen, as an
+    // explicit Factory URL (see factory.js).
+    if (ctx.bootAsset) {
+      args.push(ctx.bootAsset.flag, ctx.bootAsset.url);
+      if (ctx.bootAsset.secureboot) {
+        // What the iso-secureboot preset sets (iso_secureboot_preset.go): TPM 2.0
+        // plus TPM-keyed state/ephemeral encryption. Needs swtpm on the runner.
+        args.push("--with-tpm2");
+        args.push("--encrypt-state");
+        args.push("--encrypt-ephemeral");
+        push("--disk-encryption-key-types", "tpm");
+      }
+    }
+
+    // dev defaults to the generic installer, which silently drops schematic
+    // extensions on the first upgrade; the qemu subcommand pins this itself in
+    // applyDefaultSettings.
+    push("--install-image", ctx.installImage);
+
+    // Replicates the qemu subcommand's lifecycle: nodes boot to maintenance mode
+    // and the config is applied over the API, never injected into the boot.
+    // Under the maintenance preset nothing is applied and there is no cluster to
+    // wait for.
+    args.push("--skip-injecting-config");
+    if (hasMaintenancePreset(cluster)) {
+      args.push("--wait=false");
+    } else {
+      args.push("--with-apply-config");
+    }
   } else {
     const docker = spec.docker ?? {};
+
+    push("--cpus-controlplanes", spec.controlplanes?.cpus);
+    push("--memory-controlplanes", spec.controlplanes?.memory);
+    push("--cpus-workers", spec.workers?.cpus);
+    push("--memory-workers", spec.workers?.memory);
+
+    push("--subnet", spec.network?.cidr);
+    // --mtu is registered in getCommonUserFacingFlags and merely MarkHidden;
+    // docker feeds it to the bridge as com.docker.network.driver.mtu.
+    push("--mtu", spec.network?.mtu);
 
     push("--image", docker.image);
     push("--host-ip", docker["host-ip"]);
@@ -98155,12 +98397,17 @@ function buildArgs(cluster, ctx = {}) {
 
   // Repeated flags, one per patch. These are StringArray rather than StringSlice
   // flags, so pflag does not split on commas and a JSON patch survives intact.
-  for (const patch of ctx.patches?.cluster ?? []) args.push("--config-patch", patch);
-  for (const patch of ctx.patches?.controlplanes ?? [])
-    args.push("--config-patch-controlplanes", patch);
-  for (const patch of ctx.patches?.workers ?? []) args.push("--config-patch-workers", patch);
+  // dev and docker also disagree on the role flag names.
+  const [cpFlag, workerFlag] =
+    provider === "qemu"
+      ? ["--config-patch-control-plane", "--config-patch-worker"]
+      : ["--config-patch-controlplanes", "--config-patch-workers"];
 
-  push("--talosconfig-destination", ctx.talosconfig);
+  for (const patch of ctx.patches?.cluster ?? []) args.push("--config-patch", patch);
+  for (const patch of ctx.patches?.controlplanes ?? []) args.push(cpFlag, patch);
+  for (const patch of ctx.patches?.workers ?? []) args.push(workerFlag, patch);
+
+  push(provider === "qemu" ? "--talosconfig" : "--talosconfig-destination", ctx.talosconfig);
 
   return args;
 }
@@ -98212,19 +98459,18 @@ const PROVIDER_KEYS = {
   docker: new Set(Object.keys(schema.properties.spec.properties.docker.properties)),
 };
 
-// Keys that read as obvious but that `cluster create qemu` does not expose. Without
-// these, `additionalProperties: false` reports a bare "unknown property" and leaves
-// the reader to discover the reason from talosctl's source.
+// Keys that read as obvious but that the spec does not expose. Without these,
+// `additionalProperties: false` reports a bare "unknown property" and leaves the
+// reader guessing at the reason.
 const UNSUPPORTED = {
   "spec.network.ipv6":
-    "IPv6 is only available on `talosctl cluster create dev`, which cannot use Image Factory schematics. For IPv6 inside the cluster, patch cluster.network.podSubnets/serviceSubnets under spec.config-patches instead.",
-  "spec.network.ipv4":
-    "IPv4 is always on for `cluster create qemu`; the toggle exists only on `cluster create dev`.",
-  "spec.network.nameservers": "Only available on `talosctl cluster create dev`.",
+    "Not exposed by this action yet. For IPv6 inside the cluster, patch cluster.network.podSubnets/serviceSubnets under spec.config-patches instead.",
+  "spec.network.ipv4": "IPv4 is always on.",
+  "spec.network.nameservers": "Not exposed by this action.",
   "spec.install-image":
-    "Not exposed by `cluster create qemu`. Pin machine.install.image through spec.config-patches, using ${SCHEMATIC_ID} to match the schematic this action registers.",
+    "The action pins machine.install.image to the Factory installer for the schematic in play itself; to override it anyway, patch machine.install.image through spec.config-patches.",
   "spec.registry-mirror":
-    "Not exposed by `cluster create qemu`. Patch machine.registries.mirrors under spec.config-patches instead, with ${GATEWAY} to reach a mirror the runner serves.",
+    "Patch machine.registries.mirrors under spec.config-patches instead, with ${GATEWAY} to reach a mirror the runner serves.",
   "spec.config-patches.all":
     "Patches applied to every node go under spec.config-patches.cluster, alongside controlplanes and workers.",
   "spec.controlplanes.disk": "Disks are cluster-wide, not per role. Use spec.qemu.disks.",
@@ -98328,6 +98574,16 @@ function parseCluster(source) {
 
   if (doc.spec?.qemu?.schematic && doc.spec?.qemu?.["schematic-id"]) {
     problems.push("spec.qemu.schematic and spec.qemu.schematic-id are mutually exclusive");
+  }
+
+  // The action maps the boot-method preset onto the dev subcommand's path flags
+  // itself, so this validation no longer happens inside talosctl.
+  const bootMethods = (doc.spec?.qemu?.presets ?? []).filter((preset) => preset !== "maintenance");
+  if (bootMethods.length > 1) {
+    problems.push(
+      `spec.qemu.presets names more than one boot method (${bootMethods.join(", ")}); ` +
+        "exactly one of iso, iso-secureboot, pxe, or disk-image may be present",
+    );
   }
 
   // docker never registers --controlplanes; it always runs exactly one.
@@ -98878,18 +99134,6 @@ const DISCOVERY = {
   patch: { cluster: { discovery: { enabled: false } } },
 };
 
-// talosctl never sets machine.install.image, so nodes come up on the generic
-// installer. On the first `talosctl upgrade` that silently drops every extension the
-// schematic baked in. Only meaningful when a schematic is in play.
-const INSTALL_IMAGE = {
-  name: "install image pinned to the schematic",
-  patch: {
-    machine: {
-      install: { image: "factory.talos.dev/installer/${SCHEMATIC_ID}:${TALOS_VERSION}" },
-    },
-  },
-};
-
 // Trades durability for I/O, which is the right trade for a cluster that is destroyed
 // at the end of the run. Talos only rejects the etcd args it manages for cluster
 // membership, so this one passes through.
@@ -98921,26 +99165,25 @@ function profileKernelArgs(profile, provider = DEFAULT_PROVIDER) {
 
 /**
  * Patches the profile contributes, by role. Emitted before the caller's own patches
- * so that theirs win.
+ * so that theirs win. The install image is not among them: the action always pins
+ * it via --install-image, the same way `cluster create qemu` pins it itself.
  */
-function profilePatches(profile, { hasSchematic = false } = {}) {
+function profilePatches(profile) {
   if (profile !== "ephemeral") return emptyPatches();
 
-  const cluster = [KUBELET_GC, IMAGE_PULLS, TIME_SYNC, DISCOVERY];
-
   return {
-    cluster: hasSchematic ? [...cluster, INSTALL_IMAGE] : cluster,
+    cluster: [KUBELET_GC, IMAGE_PULLS, TIME_SYNC, DISCOVERY],
     controlplanes: [ETCD_FSYNC, AUDIT_POLICY],
     workers: [],
   };
 }
 
 /** One line per thing the profile did, so a run never applies anything unannounced. */
-function describeProfile(profile, options = {}) {
+function describeProfile(profile, { provider = DEFAULT_PROVIDER } = {}) {
   if (profile !== "ephemeral") return [];
 
-  const { cluster, controlplanes, workers } = profilePatches(profile, options);
-  const args = profileKernelArgs(profile, options.provider);
+  const { cluster, controlplanes, workers } = profilePatches(profile);
+  const args = profileKernelArgs(profile, provider);
 
   return [
     ...(args.length ? [`kernel args: ${args.join(" ")}`] : []),
@@ -99025,14 +99268,32 @@ async function run() {
 
   // Profile first: talosctl applies patches in order with a deep merge, so the
   // caller's patches override the profile key by key and leave the rest standing.
-  const profileOptions = { hasSchematic: Boolean(schematicId), provider };
   const patches = concatPatches(
-    resolveProfilePatches(profilePatches(profile, profileOptions), { vars }),
+    resolveProfilePatches(profilePatches(profile), { vars }),
     resolvePatches(cluster, { baseDir, vars }),
   );
 
-  for (const line of describeProfile(profile, profileOptions)) {
+  for (const line of describeProfile(profile)) {
     info(`profile ${profile}: ${line}`);
+  }
+
+  // The dev subcommand takes boot media as URLs rather than a schematic id, so
+  // the action builds the same Factory references the qemu subcommand's presets
+  // would have (see factory.js), and pins the install image the way the qemu
+  // subcommand's applyDefaultSettings does.
+  const factoryUrl = qemu["image-factory"]?.url;
+  const asset = isQemu
+    ? bootAsset({ presets: qemu.presets, factoryUrl, schematicId, talosVersion })
+    : undefined;
+  const installImage = isQemu
+    ? installerImage({ factoryUrl, schematicId, talosVersion, secureboot: asset.secureboot })
+    : undefined;
+
+  // dev has no --image-factory-auth; a private factory's boot media is fetched by
+  // the action itself, with credentials in headers rather than argv, into the
+  // URL-keyed cache talosctl checks before downloading anything.
+  if (isQemu && factoryAuth) {
+    await preseedBootAssets([asset.url], factoryAuth);
   }
 
   for (const patch of [...patches.cluster, ...patches.controlplanes, ...patches.workers]) {
@@ -99074,7 +99335,13 @@ async function run() {
   const talosconfig = path$1.join(configDir, "talosconfig");
   const kubeconfig = path$1.join(configDir, "kubeconfig");
 
-  const args = buildArgs(cluster, { schematicId, patches, talosconfig });
+  const args = buildArgs(cluster, {
+    patches,
+    talosconfig,
+    talosVersion,
+    bootAsset: asset,
+    installImage,
+  });
 
   // The QEMU provisioner's first preflight check is `os.Geteuid() != 0`, so root is
   // not a nicety there, it is a hard gate. `-E` matters as much as the elevation:

--- a/dist/index.js
+++ b/dist/index.js
@@ -98951,13 +98951,16 @@ async function assertUsableVersion(binary) {
 /**
  * The same floor for the Talos version the nodes will run: the profile's typed
  * documents are unknown kinds to a pre-1.14 node, which rejects the whole config.
+ * On qemu that version is spec.qemu.talos-version; on docker it is the container
+ * image tag. Caught here as a clear error instead of ten minutes of handshake
+ * failures against a node that rejected its config.
  */
-function assertSupportedTargetVersion(talosVersion) {
+function assertSupportedTargetVersion(talosVersion, source = "spec.qemu.talos-version") {
   if (!meetsMinimum(talosVersion)) {
     throw new Error(
-      `spec.qemu.talos-version ${talosVersion} is below v${MINIMUM_TALOS_VERSION}: this action ` +
-        "targets Talos 1.14+, whose configs carry the typed documents the ephemeral profile " +
-        "emits. Pin an older release of this action for older Talos.",
+      `${source} ${talosVersion} is below v${MINIMUM_TALOS_VERSION}: this action targets ` +
+        "Talos 1.14+, whose configs carry the typed documents the ephemeral profile emits. " +
+        "Pin an older release of this action for older Talos.",
     );
   }
 }
@@ -99290,8 +99293,14 @@ async function run() {
   // the profile's install-image pin, and the Factory publishes no unprefixed tag.
   const talosVersion = withV(qemu["talos-version"] ?? clientVersion);
   // The version the nodes will run, not just the binary: a pre-1.14 node rejects
-  // the typed config documents the profile emits.
-  if (isQemu) assertSupportedTargetVersion(talosVersion);
+  // the typed config documents the profile emits. On docker that version is the
+  // container image tag, when it carries one.
+  if (isQemu) {
+    assertSupportedTargetVersion(talosVersion);
+  } else {
+    const imageTag = /:(v?\d+\.\d+\.\d+\S*)$/.exec(cluster.spec?.docker?.image ?? "")?.[1];
+    if (imageTag) assertSupportedTargetVersion(imageTag, "the spec.docker.image tag");
+  }
 
   const vars = substitutions({ schematicId, cluster, talosVersion, gateway: addresses.gateway });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -98365,6 +98365,11 @@ function buildArgs(cluster, ctx = {}) {
     // applyDefaultSettings.
     push("--install-image", ctx.installImage);
 
+    // No DiscoveryServiceConfig document is generated at all, which is how 1.14
+    // configs turn the public discovery service off. A spec that wants it back
+    // adds its own document via config-patches.
+    args.push("--with-cluster-discovery=false");
+
     // Replicates the qemu subcommand's lifecycle: nodes boot to maintenance mode
     // and the config is applied over the API, never injected into the boot.
     // Under the maintenance preset nothing is applied and there is no cluster to
@@ -98894,12 +98899,11 @@ async function defaultTalosVersion(binary) {
   return parseVersionOutput(stdout);
 }
 
-// v1.12 split `cluster create` into `qemu` and `docker` subcommands, but the floor is
-// v1.13 because the action emits flags that landed after that split: v1.12 has no
-// --image-factory-auth, and its disk parser is a SplitN(":", 2) that cannot read the
-// :tag= / :serial= parameters this schema accepts. Gating on v1.12 would admit users
-// who then hit the bare cobra errors this check exists to prevent.
-const MINIMUM_TALOS_VERSION = "1.13.0";
+// This action targets Talos 1.14: the ephemeral profile is written as the typed
+// config documents (KubeletConfig, KubeAuditPolicyConfig) that 1.14-contract
+// configs generate, and a pre-1.14 node rejects those kinds as unknown. Repos on
+// older Talos should pin an older action release rather than upgrade.
+const MINIMUM_TALOS_VERSION = "1.14.0";
 
 const parseVersion = (tag) =>
   (tag ?? "")
@@ -98935,13 +98939,27 @@ async function assertUsableVersion(binary) {
 
   if (!meetsMinimum(version)) {
     throw new Error(
-      `talosctl ${version} is too old: this action needs at least v${MINIMUM_TALOS_VERSION}, ` +
-        "which is where `cluster create` gained the `qemu` and `docker` subcommands and the " +
-        "flag names used here.",
+      `talosctl ${version} is too old: this action targets Talos v${MINIMUM_TALOS_VERSION} and ` +
+        "newer, whose configs use the typed multi-documents the ephemeral profile is written " +
+        "as. Pin an older release of this action for older Talos.",
     );
   }
 
   return version;
+}
+
+/**
+ * The same floor for the Talos version the nodes will run: the profile's typed
+ * documents are unknown kinds to a pre-1.14 node, which rejects the whole config.
+ */
+function assertSupportedTargetVersion(talosVersion) {
+  if (!meetsMinimum(talosVersion)) {
+    throw new Error(
+      `spec.qemu.talos-version ${talosVersion} is below v${MINIMUM_TALOS_VERSION}: this action ` +
+        "targets Talos 1.14+, whose configs carry the typed documents the ephemeral profile " +
+        "emits. Pin an older release of this action for older Talos.",
+    );
+  }
 }
 
 /**
@@ -99074,20 +99092,20 @@ const KERNEL_ARGS = [
 // Borrowed from kind. A node's disk holds two full sets of Kubernetes images plus the
 // Talos installer; if kubelet's default thresholds trip partway through a run it
 // garbage-collects images and evicts pods, which reads as a flaky test rather than a
-// disk problem. Nothing here is reclaimed anyway, the VM is deleted.
+// disk problem. Nothing here is reclaimed anyway, the VM is deleted. Written as the
+// 1.14 KubeletConfig document: a 1.14-contract config generates that document, and
+// Talos rejects a bundle that also sets .machine.kubelet in the v1alpha1 sections.
 const KUBELET_GC = {
   name: "kubelet GC and eviction thresholds",
   patch: {
-    machine: {
-      kubelet: {
-        extraConfig: {
-          imageGCHighThresholdPercent: 100,
-          evictionHard: {
-            "nodefs.available": "0%",
-            "nodefs.inodesFree": "0%",
-            "imagefs.available": "0%",
-          },
-        },
+    apiVersion: "v1alpha1",
+    kind: "KubeletConfig",
+    config: {
+      imageGCHighThresholdPercent: 100,
+      evictionHard: {
+        "nodefs.available": "0%",
+        "nodefs.inodesFree": "0%",
+        "imagefs.available": "0%",
       },
     },
   },
@@ -99102,13 +99120,11 @@ const KUBELET_GC = {
 const IMAGE_PULLS = {
   name: "parallel image pulls",
   patch: {
-    machine: {
-      kubelet: {
-        extraConfig: {
-          serializeImagePulls: false,
-          maxParallelImagePulls: 3,
-        },
-      },
+    apiVersion: "v1alpha1",
+    kind: "KubeletConfig",
+    config: {
+      serializeImagePulls: false,
+      maxParallelImagePulls: 3,
     },
   },
 };
@@ -99125,13 +99141,20 @@ const TIME_SYNC = {
   patch: { machine: { time: { disabled: true } } },
 };
 
-// talosctl hard-codes EnableClusterDiscovery, and its qemu subcommand exposes no flag
-// to turn it off, so every throwaway cluster registers its nodes as affiliates with the
-// public discovery service at discovery.talos.dev. Nothing here needs it: the nodes sit
-// on a local bridge at addresses the provisioner assigned, and KubeSpan is off.
-const DISCOVERY = {
+// Nothing here needs the public discovery service: the nodes sit on a local bridge
+// at addresses the provisioner assigned, and KubeSpan is off. The qemu provider
+// turns it off at generation time (--with-cluster-discovery=false, so no
+// DiscoveryServiceConfig document is emitted at all); the docker subcommand has no
+// such flag, so there the profile deletes the generated document instead. Wanting
+// it back on means adding your own DiscoveryServiceConfig document.
+const DISCOVERY_DELETE = {
   name: "cluster discovery service off",
-  patch: { cluster: { discovery: { enabled: false } } },
+  patch: {
+    apiVersion: "v1alpha1",
+    kind: "DiscoveryServiceConfig",
+    name: "default",
+    $patch: "delete",
+  },
 };
 
 // Trades durability for I/O, which is the right trade for a cluster that is destroyed
@@ -99143,15 +99166,13 @@ const ETCD_FSYNC = {
 };
 
 // Talos logs every API request at Metadata level to /var/log/audit/kube. Nothing
-// reads it here.
+// reads it here. The 1.14 document form; its `configuration` merges by replacement.
 const AUDIT_POLICY = {
   name: "apiserver audit policy off",
   patch: {
-    cluster: {
-      apiServer: {
-        auditPolicy: { apiVersion: "audit.k8s.io/v1", kind: "Policy", rules: [{ level: "None" }] },
-      },
-    },
+    apiVersion: "v1alpha1",
+    kind: "KubeAuditPolicyConfig",
+    configuration: { apiVersion: "audit.k8s.io/v1", kind: "Policy", rules: [{ level: "None" }] },
   },
 };
 
@@ -99165,14 +99186,17 @@ function profileKernelArgs(profile, provider = DEFAULT_PROVIDER) {
 
 /**
  * Patches the profile contributes, by role. Emitted before the caller's own patches
- * so that theirs win. The install image is not among them: the action always pins
- * it via --install-image, the same way `cluster create qemu` pins it itself.
+ * so that theirs win. The install image is not among them (the action always pins
+ * it via --install-image), and neither is discovery on the qemu provider (turned
+ * off at generation time via --with-cluster-discovery=false).
  */
-function profilePatches(profile) {
+function profilePatches(profile, provider = DEFAULT_PROVIDER) {
   if (profile !== "ephemeral") return emptyPatches();
 
+  const cluster = [KUBELET_GC, IMAGE_PULLS, TIME_SYNC];
+
   return {
-    cluster: [KUBELET_GC, IMAGE_PULLS, TIME_SYNC, DISCOVERY],
+    cluster: provider === "docker" ? [...cluster, DISCOVERY_DELETE] : cluster,
     controlplanes: [ETCD_FSYNC, AUDIT_POLICY],
     workers: [],
   };
@@ -99182,12 +99206,13 @@ function profilePatches(profile) {
 function describeProfile(profile, { provider = DEFAULT_PROVIDER } = {}) {
   if (profile !== "ephemeral") return [];
 
-  const { cluster, controlplanes, workers } = profilePatches(profile);
+  const { cluster, controlplanes, workers } = profilePatches(profile, provider);
   const args = profileKernelArgs(profile, provider);
 
   return [
     ...(args.length ? [`kernel args: ${args.join(" ")}`] : []),
     ...[...cluster, ...controlplanes, ...workers].map((entry) => entry.name),
+    ...(provider === "docker" ? [] : ["cluster discovery service off"]),
   ];
 }
 
@@ -99264,12 +99289,16 @@ async function run() {
   // v-prefixed here, not just on the flag: this value also fills ${TALOS_VERSION} in
   // the profile's install-image pin, and the Factory publishes no unprefixed tag.
   const talosVersion = withV(qemu["talos-version"] ?? clientVersion);
+  // The version the nodes will run, not just the binary: a pre-1.14 node rejects
+  // the typed config documents the profile emits.
+  if (isQemu) assertSupportedTargetVersion(talosVersion);
+
   const vars = substitutions({ schematicId, cluster, talosVersion, gateway: addresses.gateway });
 
   // Profile first: talosctl applies patches in order with a deep merge, so the
   // caller's patches override the profile key by key and leave the rest standing.
   const patches = concatPatches(
-    resolveProfilePatches(profilePatches(profile), { vars }),
+    resolveProfilePatches(profilePatches(profile, provider), { vars }),
     resolvePatches(cluster, { baseDir, vars }),
   );
 

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -22,7 +22,7 @@ spec:
 
   docker:
     # docker's equivalent of the qemu provider's talos-version.
-    image: ghcr.io/siderolabs/talos:v1.13.6
+    image: ghcr.io/siderolabs/talos:v1.14.0-beta.1
 
   # The profile still applies the parts that make sense here: the kubelet, etcd, and
   # audit settings. Its kernel args are skipped, because those ride in an Image

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -24,7 +24,7 @@ spec:
     cidr: 10.5.0.0/24
 
   qemu:
-    talos-version: v1.13.6
+    talos-version: v1.14.0-beta.1
 
     # The first disk goes to every node; the second is attached to workers only.
     disks:

--- a/examples/matrix/1cp-0w.yaml
+++ b/examples/matrix/1cp-0w.yaml
@@ -9,7 +9,7 @@ metadata:
   name: e2e-1cp-0w
 spec:
   qemu:
-    talos-version: v1.13.6
+    talos-version: v1.14.0-beta.1
   controlplanes:
     count: 1
   workers:

--- a/examples/matrix/1cp-1w.yaml
+++ b/examples/matrix/1cp-1w.yaml
@@ -9,7 +9,7 @@ metadata:
   name: e2e-1cp-1w
 spec:
   qemu:
-    talos-version: v1.13.6
+    talos-version: v1.14.0-beta.1
   controlplanes:
     count: 1
   workers:

--- a/examples/matrix/3cp-0w.yaml
+++ b/examples/matrix/3cp-0w.yaml
@@ -10,7 +10,7 @@ metadata:
   name: e2e-3cp-0w
 spec:
   qemu:
-    talos-version: v1.13.6
+    talos-version: v1.14.0-beta.1
   controlplanes:
     count: 3
   workers:

--- a/schema/talos-cluster.json
+++ b/schema/talos-cluster.json
@@ -9,26 +9,51 @@
   "definitions": {
     "patch": {
       "description": "An inline machine config patch, or \"@path\" to read one from a file relative to the config file.",
-      "oneOf": [{ "type": "object" }, { "type": "string", "pattern": "^@.+", "minLength": 2 }]
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "pattern": "^@.+",
+          "minLength": 2
+        }
+      ]
     },
     "cpus": {
       "description": "Share of host CPUs per node, as a fraction. Maps to --cpus-{controlplanes,workers}.",
       "oneOf": [
-        { "type": "number", "exclusiveMinimum": 0 },
-        { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?$" }
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?$"
+        }
       ]
     },
     "memory": {
       "description": "Memory limit per node. A bare number is MiB, matching talosctl's default unit. Maps to --memory-{controlplanes,workers}.",
       "oneOf": [
-        { "type": "number", "exclusiveMinimum": 0 },
-        { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?\\s*([KMGT]i?B|B)?$" }
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?\\s*([KMGT]i?B|B)?$"
+        }
       ]
     }
   },
   "properties": {
-    "apiVersion": { "const": "v1alpha1" },
-    "kind": { "const": "TalosCluster" },
+    "apiVersion": {
+      "const": "v1alpha1"
+    },
+    "kind": {
+      "const": "TalosCluster"
+    },
     "metadata": {
       "type": "object",
       "additionalProperties": false,
@@ -70,17 +95,28 @@
               "type": "integer",
               "minimum": 1
             },
-            "cpus": { "$ref": "#/definitions/cpus" },
-            "memory": { "$ref": "#/definitions/memory" }
+            "cpus": {
+              "$ref": "#/definitions/cpus"
+            },
+            "memory": {
+              "$ref": "#/definitions/memory"
+            }
           }
         },
         "workers": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "count": { "type": "integer", "minimum": 0 },
-            "cpus": { "$ref": "#/definitions/cpus" },
-            "memory": { "$ref": "#/definitions/memory" }
+            "count": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "cpus": {
+              "$ref": "#/definitions/cpus"
+            },
+            "memory": {
+              "$ref": "#/definitions/memory"
+            }
           }
         },
         "network": {
@@ -107,17 +143,23 @@
             "cluster": {
               "description": "Applied to every node. Maps to --config-patch.",
               "type": "array",
-              "items": { "$ref": "#/definitions/patch" }
+              "items": {
+                "$ref": "#/definitions/patch"
+              }
             },
             "controlplanes": {
               "description": "Applied to control plane nodes. Maps to --config-patch-controlplanes.",
               "type": "array",
-              "items": { "$ref": "#/definitions/patch" }
+              "items": {
+                "$ref": "#/definitions/patch"
+              }
             },
             "workers": {
               "description": "Applied to worker nodes. Maps to --config-patch-workers.",
               "type": "array",
-              "items": { "$ref": "#/definitions/patch" }
+              "items": {
+                "$ref": "#/definitions/patch"
+              }
             }
           }
         },
@@ -132,7 +174,7 @@
               "minLength": 1
             },
             "disks": {
-              "description": "Disks per node, as \"driver:size\" with optional \":tag=\" / \":serial=\" parameters. Maps to a single --disks flag. The first disk goes to every node; any after it are attached to workers only.",
+              "description": "Disks per node, as \"driver:size\" with optional \":tag=\" / \":serial=\" parameters. The first disk goes to every node, must be virtio, and carries no parameters; any after it are attached to workers only and must all share one size (per-disk drivers, tags, and serials are fine).",
               "type": "array",
               "minItems": 1,
               "items": {
@@ -143,8 +185,14 @@
             "schematic": {
               "description": "Image Factory schematic, inline or \"@path\". Registered with the factory at run time; the returned id is passed as --schematic-id. Mutually exclusive with schematic-id.",
               "oneOf": [
-                { "type": "object" },
-                { "type": "string", "pattern": "^@.+", "minLength": 2 }
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "string",
+                  "pattern": "^@.+",
+                  "minLength": 2
+                }
               ]
             },
             "schematic-id": {
@@ -171,7 +219,9 @@
               "description": "Boot presets. Maps to --presets. Exactly one of iso, iso-secureboot, pxe, or disk-image must be present. Adding maintenance leaves the nodes unconfigured in maintenance mode: the action then skips the kubeconfig fetch and exports neither KUBECONFIG nor TALOSCONFIG, handing over only the node addresses.",
               "type": "array",
               "minItems": 1,
-              "items": { "enum": ["iso", "iso-secureboot", "pxe", "disk-image", "maintenance"] }
+              "items": {
+                "enum": ["iso", "iso-secureboot", "pxe", "disk-image", "maintenance"]
+              }
             }
           }
         },
@@ -196,7 +246,10 @@
             "mounts": {
               "description": "Mounts to attach to each container, in `docker --mount` syntax. Maps to a repeated --mount.",
               "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
             }
           }
         }

--- a/src/args.js
+++ b/src/args.js
@@ -160,6 +160,11 @@ export function buildArgs(cluster, ctx = {}) {
     // applyDefaultSettings.
     push("--install-image", ctx.installImage);
 
+    // No DiscoveryServiceConfig document is generated at all, which is how 1.14
+    // configs turn the public discovery service off. A spec that wants it back
+    // adds its own document via config-patches.
+    args.push("--with-cluster-discovery=false");
+
     // Replicates the qemu subcommand's lifecycle: nodes boot to maintenance mode
     // and the config is applied over the API, never injected into the boot.
     // Under the maintenance preset nothing is applied and there is no cluster to

--- a/src/args.js
+++ b/src/args.js
@@ -25,10 +25,84 @@ export const providerOf = (cluster) => cluster.spec?.provider ?? DEFAULT_PROVIDE
 export const hasMaintenancePreset = (cluster) =>
   Boolean(cluster.spec?.qemu?.presets?.includes("maintenance"));
 
+// One disk entry: driver, a size with unit, then optional :tag= / :serial= params.
+const DISK_RE = /^([a-z0-9]+):([0-9]+(?:\.[0-9]+)?)\s*([KMGT]i?B|B)?((?::[a-z]+=[^:]+)*)$/;
+
+const UNIT_MB = {
+  B: 1 / (1024 * 1024),
+  KB: 1 / 1024,
+  KiB: 1 / 1024,
+  MB: 1,
+  MiB: 1,
+  GB: 1024,
+  GiB: 1024,
+  TB: 1024 * 1024,
+  TiB: 1024 * 1024,
+};
+
+/**
+ * Map spec.qemu.disks onto `cluster create dev`'s count-based disk flags.
+ *
+ * The dev subcommand kept the legacy disk interface: one virtio primary sized in
+ * MB, plus N worker-only extra disks that share a single size but carry per-disk
+ * drivers, tags, and serials. The list syntax stays expressible with two
+ * constraints, both rejected here with the reason rather than silently mangled:
+ * the primary must be virtio, and every extra disk must be the same size.
+ */
+export function translateDisks(disks) {
+  const parse = (entry, position) => {
+    const match = DISK_RE.exec(entry);
+    if (!match) throw new Error(`spec.qemu.disks[${position}]: cannot parse '${entry}'`);
+
+    const [, driver, size, unit = "MiB", params] = match;
+    const mb = Math.round(Number(size) * UNIT_MB[unit]);
+    const tag = /:tag=([^:]+)/.exec(params)?.[1] ?? "";
+    const serial = /:serial=([^:]+)/.exec(params)?.[1] ?? "";
+
+    return { driver, mb, tag, serial };
+  };
+
+  const [primary, ...extras] = disks.map(parse);
+
+  if (primary.driver !== "virtio") {
+    throw new Error(
+      `spec.qemu.disks[0]: the primary disk must be virtio; '${primary.driver}' is only ` +
+        "available for the extra worker disks",
+    );
+  }
+  if (primary.tag || primary.serial) {
+    throw new Error("spec.qemu.disks[0]: tag= and serial= are only available on extra disks");
+  }
+
+  const sizes = new Set(extras.map((disk) => disk.mb));
+  if (sizes.size > 1) {
+    throw new Error(
+      "spec.qemu.disks: extra disks must all be the same size " +
+        `(got ${[...sizes].join("MB, ")}MB); talosctl's dev interface sizes them together`,
+    );
+  }
+
+  return {
+    disk: primary.mb,
+    extraDisks: extras.length,
+    extraDisksSize: extras[0]?.mb,
+    drivers: extras.map((disk) => disk.driver),
+    tags: extras.map((disk) => disk.tag),
+    serials: extras.map((disk) => disk.serial),
+  };
+}
+
 export function buildArgs(cluster, ctx = {}) {
   const spec = cluster.spec ?? {};
   const provider = providerOf(cluster);
-  const args = ["cluster", "create", provider, "--name", cluster.metadata.name];
+
+  // The qemu provider is driven through `cluster create dev`: upstream froze the
+  // qemu subcommand's flag surface and points anyone needing the full set (boot
+  // media paths, install image, network shaping) at dev. The action pins the
+  // exact behavior the qemu subcommand had — same Factory media, same
+  // maintenance-boot + API-apply lifecycle — through explicit flags.
+  const args = ["cluster", "create", provider === "qemu" ? "dev" : provider];
+  args.push("--name", cluster.metadata.name);
 
   const push = (flag, value) => {
     if (value !== undefined && value !== null) args.push(flag, String(value));
@@ -36,39 +110,78 @@ export function buildArgs(cluster, ctx = {}) {
 
   push("--kubernetes-version", spec["kubernetes-version"] && withoutV(spec["kubernetes-version"]));
 
-  // Shared, except --controlplanes: docker never registers it and always runs exactly
-  // one, so passing it would be an unknown-flag error rather than a no-op.
-  if (provider === "qemu") push("--controlplanes", spec.controlplanes?.count);
-  push("--cpus-controlplanes", spec.controlplanes?.cpus);
-  push("--memory-controlplanes", spec.controlplanes?.memory);
-
   push("--workers", spec.workers?.count);
-  push("--cpus-workers", spec.workers?.cpus);
-  push("--memory-workers", spec.workers?.memory);
-
-  // Same underlying option, different flag name per subcommand. --mtu is shared: it
-  // is registered in getCommonUserFacingFlags and merely MarkHidden, so it is absent
-  // from `--help` but accepted by both, and docker feeds it to the bridge as
-  // com.docker.network.driver.mtu.
-  push(provider === "docker" ? "--subnet" : "--cidr", spec.network?.cidr);
-  push("--mtu", spec.network?.mtu);
 
   if (provider === "qemu") {
     const qemu = spec.qemu ?? {};
 
-    push("--talos-version", qemu["talos-version"] && withV(qemu["talos-version"]));
+    // dev renamed the control-plane resource flags; the worker ones match.
+    push("--controlplanes", spec.controlplanes?.count);
+    push("--cpus", spec.controlplanes?.cpus);
+    push("--memory", spec.controlplanes?.memory);
+    push("--cpus-workers", spec.workers?.cpus);
+    push("--memory-workers", spec.workers?.memory);
 
-    // One comma-joined flag, not repeated flags: the Disks pflag.Value replaces its
-    // accumulated list on every Set, so `--disks a --disks b` silently keeps only b.
-    if (qemu.disks?.length) push("--disks", qemu.disks.join(","));
+    push("--cidr", spec.network?.cidr);
+    push("--mtu", spec.network?.mtu);
 
-    push("--schematic-id", ctx.schematicId);
-    push("--image-factory-url", qemu["image-factory"]?.url);
-    push("--image-factory-auth", qemu["image-factory"]?.auth);
+    if (qemu.disks?.length) {
+      const disks = translateDisks(qemu.disks);
+      push("--disk", disks.disk);
+      if (disks.extraDisks > 0) {
+        push("--extra-disks", disks.extraDisks);
+        push("--extra-disks-size", disks.extraDisksSize);
+        push("--extra-disks-drivers", disks.drivers.join(","));
+        if (disks.tags.some(Boolean)) push("--extra-disks-tags", disks.tags.join(","));
+        if (disks.serials.some(Boolean)) push("--extra-disks-serials", disks.serials.join(","));
+      }
+    }
 
-    if (qemu.presets?.length) push("--presets", qemu.presets.join(","));
+    // Always passed: dev defaults to "latest", and the boot asset URLs and the
+    // install image pin below already embed the resolved version.
+    push("--talos-version", ctx.talosVersion);
+
+    // The boot media the qemu subcommand's preset would have chosen, as an
+    // explicit Factory URL (see factory.js).
+    if (ctx.bootAsset) {
+      args.push(ctx.bootAsset.flag, ctx.bootAsset.url);
+      if (ctx.bootAsset.secureboot) {
+        // What the iso-secureboot preset sets (iso_secureboot_preset.go): TPM 2.0
+        // plus TPM-keyed state/ephemeral encryption. Needs swtpm on the runner.
+        args.push("--with-tpm2");
+        args.push("--encrypt-state");
+        args.push("--encrypt-ephemeral");
+        push("--disk-encryption-key-types", "tpm");
+      }
+    }
+
+    // dev defaults to the generic installer, which silently drops schematic
+    // extensions on the first upgrade; the qemu subcommand pins this itself in
+    // applyDefaultSettings.
+    push("--install-image", ctx.installImage);
+
+    // Replicates the qemu subcommand's lifecycle: nodes boot to maintenance mode
+    // and the config is applied over the API, never injected into the boot.
+    // Under the maintenance preset nothing is applied and there is no cluster to
+    // wait for.
+    args.push("--skip-injecting-config");
+    if (hasMaintenancePreset(cluster)) {
+      args.push("--wait=false");
+    } else {
+      args.push("--with-apply-config");
+    }
   } else {
     const docker = spec.docker ?? {};
+
+    push("--cpus-controlplanes", spec.controlplanes?.cpus);
+    push("--memory-controlplanes", spec.controlplanes?.memory);
+    push("--cpus-workers", spec.workers?.cpus);
+    push("--memory-workers", spec.workers?.memory);
+
+    push("--subnet", spec.network?.cidr);
+    // --mtu is registered in getCommonUserFacingFlags and merely MarkHidden;
+    // docker feeds it to the bridge as com.docker.network.driver.mtu.
+    push("--mtu", spec.network?.mtu);
 
     push("--image", docker.image);
     push("--host-ip", docker["host-ip"]);
@@ -79,12 +192,17 @@ export function buildArgs(cluster, ctx = {}) {
 
   // Repeated flags, one per patch. These are StringArray rather than StringSlice
   // flags, so pflag does not split on commas and a JSON patch survives intact.
-  for (const patch of ctx.patches?.cluster ?? []) args.push("--config-patch", patch);
-  for (const patch of ctx.patches?.controlplanes ?? [])
-    args.push("--config-patch-controlplanes", patch);
-  for (const patch of ctx.patches?.workers ?? []) args.push("--config-patch-workers", patch);
+  // dev and docker also disagree on the role flag names.
+  const [cpFlag, workerFlag] =
+    provider === "qemu"
+      ? ["--config-patch-control-plane", "--config-patch-worker"]
+      : ["--config-patch-controlplanes", "--config-patch-workers"];
 
-  push("--talosconfig-destination", ctx.talosconfig);
+  for (const patch of ctx.patches?.cluster ?? []) args.push("--config-patch", patch);
+  for (const patch of ctx.patches?.controlplanes ?? []) args.push(cpFlag, patch);
+  for (const patch of ctx.patches?.workers ?? []) args.push(workerFlag, patch);
+
+  push(provider === "qemu" ? "--talosconfig" : "--talosconfig-destination", ctx.talosconfig);
 
   return args;
 }

--- a/src/cache.js
+++ b/src/cache.js
@@ -40,6 +40,44 @@ export function bootAssetsKey({
   return `talos-boot-assets-${arch}-${talosVersion}-${fingerprint}`;
 }
 
+/**
+ * The path talosctl's downloadBootAssets would cache a URL at: the full URL with
+ * '/' and ':' flattened to '-', inside the cache directory it stats before
+ * downloading.
+ */
+export const assetCachePath = (url) =>
+  path.join(bootAssetsDir(), url.replaceAll("/", "-").replaceAll(":", "-"));
+
+/**
+ * Pre-download boot assets into talosctl's own cache, authenticating with HTTP
+ * Basic. The dev subcommand has no --image-factory-auth, and credentials embedded
+ * in the URL would ride in argv; fetching here keeps them in headers, and
+ * talosctl's cache check makes the URL a no-op download afterwards.
+ */
+export async function preseedBootAssets(urls, auth) {
+  fs.mkdirSync(bootAssetsDir(), { recursive: true });
+
+  for (const url of urls) {
+    const destination = assetCachePath(url);
+    if (fs.existsSync(destination)) continue;
+
+    core.info(`Fetching ${url} into the boot asset cache`);
+
+    const response = await fetch(url, {
+      headers: { authorization: `Basic ${Buffer.from(auth).toString("base64")}` },
+    });
+    if (!response.ok) {
+      throw new Error(`could not fetch ${url}: ${response.status} ${response.statusText}`);
+    }
+
+    // Written via a temp name so a failure part-way never leaves a file that
+    // talosctl's existence check would mistake for a complete download.
+    const partial = `${destination}.partial`;
+    fs.writeFileSync(partial, Buffer.from(await response.arrayBuffer()));
+    fs.renameSync(partial, destination);
+  }
+}
+
 /** Restore the boot asset directory; returns the hit key, or undefined on a miss. */
 export async function restoreBootAssets(key) {
   if (!cache.isFeatureAvailable()) {

--- a/src/config.js
+++ b/src/config.js
@@ -25,19 +25,18 @@ const PROVIDER_KEYS = {
   docker: new Set(Object.keys(schema.properties.spec.properties.docker.properties)),
 };
 
-// Keys that read as obvious but that `cluster create qemu` does not expose. Without
-// these, `additionalProperties: false` reports a bare "unknown property" and leaves
-// the reader to discover the reason from talosctl's source.
+// Keys that read as obvious but that the spec does not expose. Without these,
+// `additionalProperties: false` reports a bare "unknown property" and leaves the
+// reader guessing at the reason.
 const UNSUPPORTED = {
   "spec.network.ipv6":
-    "IPv6 is only available on `talosctl cluster create dev`, which cannot use Image Factory schematics. For IPv6 inside the cluster, patch cluster.network.podSubnets/serviceSubnets under spec.config-patches instead.",
-  "spec.network.ipv4":
-    "IPv4 is always on for `cluster create qemu`; the toggle exists only on `cluster create dev`.",
-  "spec.network.nameservers": "Only available on `talosctl cluster create dev`.",
+    "Not exposed by this action yet. For IPv6 inside the cluster, patch cluster.network.podSubnets/serviceSubnets under spec.config-patches instead.",
+  "spec.network.ipv4": "IPv4 is always on.",
+  "spec.network.nameservers": "Not exposed by this action.",
   "spec.install-image":
-    "Not exposed by `cluster create qemu`. Pin machine.install.image through spec.config-patches, using ${SCHEMATIC_ID} to match the schematic this action registers.",
+    "The action pins machine.install.image to the Factory installer for the schematic in play itself; to override it anyway, patch machine.install.image through spec.config-patches.",
   "spec.registry-mirror":
-    "Not exposed by `cluster create qemu`. Patch machine.registries.mirrors under spec.config-patches instead, with ${GATEWAY} to reach a mirror the runner serves.",
+    "Patch machine.registries.mirrors under spec.config-patches instead, with ${GATEWAY} to reach a mirror the runner serves.",
   "spec.config-patches.all":
     "Patches applied to every node go under spec.config-patches.cluster, alongside controlplanes and workers.",
   "spec.controlplanes.disk": "Disks are cluster-wide, not per role. Use spec.qemu.disks.",
@@ -141,6 +140,16 @@ export function parseCluster(source) {
 
   if (doc.spec?.qemu?.schematic && doc.spec?.qemu?.["schematic-id"]) {
     problems.push("spec.qemu.schematic and spec.qemu.schematic-id are mutually exclusive");
+  }
+
+  // The action maps the boot-method preset onto the dev subcommand's path flags
+  // itself, so this validation no longer happens inside talosctl.
+  const bootMethods = (doc.spec?.qemu?.presets ?? []).filter((preset) => preset !== "maintenance");
+  if (bootMethods.length > 1) {
+    problems.push(
+      `spec.qemu.presets names more than one boot method (${bootMethods.join(", ")}); ` +
+        "exactly one of iso, iso-secureboot, pxe, or disk-image may be present",
+    );
   }
 
   // docker never registers --controlplanes; it always runs exactly one.

--- a/src/factory.js
+++ b/src/factory.js
@@ -1,0 +1,92 @@
+import { DEFAULT_FACTORY_URL } from "./schematic.js";
+
+/**
+ * Image Factory asset references for the dev backend.
+ *
+ * `cluster create dev` takes boot media as plain paths or URLs rather than a
+ * schematic id, so the action builds the same Factory URLs the qemu subcommand's
+ * presets would have (preset/*.go in talosctl), byte for byte: the schematic id
+ * (or the well-known empty one), the Talos version, and the metal platform's
+ * asset naming.
+ */
+
+// constants.ImageFactoryEmptySchematicID: what `cluster create qemu` substitutes
+// when no schematic is given, so a spec without one boots identical media.
+export const EMPTY_SCHEMATIC_ID =
+  "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba";
+
+// Node arch to Talos arch. The provisioner targets the host's own architecture.
+const ARCHES = { x64: "amd64", arm64: "arm64" };
+export const talosArch = (nodeArch = process.arch) => ARCHES[nodeArch] ?? "amd64";
+
+// A relative reference resolves against the base's *directory*, so a factory URL
+// with a path but no trailing slash would silently lose that path (same rule as
+// schematic registration).
+const join = (factoryUrl, ...segments) =>
+  new URL(segments.join("/"), factoryUrl.endsWith("/") ? factoryUrl : `${factoryUrl}/`).toString();
+
+/** The boot-method preset in play: the first non-maintenance entry, iso by default. */
+export const bootMethodOf = (presets) =>
+  (presets ?? []).find((preset) => preset !== "maintenance") ?? "iso";
+
+/**
+ * The dev flag and Factory URL for the spec's boot method. Mirrors talosctl's
+ * iso/iso-secureboot/pxe/disk-image presets (metal platform asset paths).
+ */
+export function bootAsset({
+  presets,
+  factoryUrl = DEFAULT_FACTORY_URL,
+  schematicId,
+  talosVersion,
+  arch = talosArch(),
+}) {
+  const id = schematicId ?? EMPTY_SCHEMATIC_ID;
+  const method = bootMethodOf(presets);
+
+  switch (method) {
+    case "iso":
+      return {
+        flag: "--iso-path",
+        url: join(factoryUrl, "image", id, talosVersion, `metal-${arch}.iso`),
+        secureboot: false,
+      };
+    case "iso-secureboot":
+      return {
+        flag: "--iso-path",
+        url: join(factoryUrl, "image", id, talosVersion, `metal-${arch}-secureboot.iso`),
+        secureboot: true,
+      };
+    case "disk-image":
+      return {
+        flag: "--disk-image-path",
+        url: join(factoryUrl, "image", id, talosVersion, `metal-${arch}.raw.zst`),
+        secureboot: false,
+      };
+    case "pxe":
+      return {
+        flag: "--ipxe-boot-script",
+        url: join(factoryUrl, "pxe", id, talosVersion, `metal-${arch}`),
+        secureboot: false,
+      };
+    default:
+      throw new Error(`unknown boot-method preset '${method}'`);
+  }
+}
+
+/**
+ * The installer image reference the stable subcommand would have pinned
+ * (applyDefaultSettings in preset.go). dev defaults to the generic installer,
+ * which would drop schematic extensions on the first `talosctl upgrade`, so it
+ * is always passed explicitly via --install-image.
+ */
+export function installerImage({
+  factoryUrl = DEFAULT_FACTORY_URL,
+  schematicId,
+  talosVersion,
+  secureboot = false,
+}) {
+  const host = new URL(factoryUrl).host;
+  const name = secureboot ? "metal-installer-secureboot" : "metal-installer";
+
+  return `${host}/${name}/${schematicId ?? EMPTY_SCHEMATIC_ID}:${talosVersion}`;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,7 @@ import {
 } from "./patches.js";
 import { registerSchematic, schematicDocument, toYaml, withKernelArgs } from "./schematic.js";
 import { waitForMaintenanceNodes } from "./maintenance.js";
-import { assertUsableVersion, resolveTalosctl } from "./talosctl.js";
+import { assertSupportedTargetVersion, assertUsableVersion, resolveTalosctl } from "./talosctl.js";
 import { assertDocker, assertKvm, assertNetworkAvailable, assertStateWritable } from "./host.js";
 import { describeProfile, profileKernelArgs, profilePatches, DEFAULT_PROFILE } from "./profile.js";
 
@@ -100,12 +100,16 @@ export async function run() {
   // v-prefixed here, not just on the flag: this value also fills ${TALOS_VERSION} in
   // the profile's install-image pin, and the Factory publishes no unprefixed tag.
   const talosVersion = withV(qemu["talos-version"] ?? clientVersion);
+  // The version the nodes will run, not just the binary: a pre-1.14 node rejects
+  // the typed config documents the profile emits.
+  if (isQemu) assertSupportedTargetVersion(talosVersion);
+
   const vars = substitutions({ schematicId, cluster, talosVersion, gateway: addresses.gateway });
 
   // Profile first: talosctl applies patches in order with a deep merge, so the
   // caller's patches override the profile key by key and leave the rest standing.
   const patches = concatPatches(
-    resolveProfilePatches(profilePatches(profile), { vars }),
+    resolveProfilePatches(profilePatches(profile, provider), { vars }),
     resolvePatches(cluster, { baseDir, vars }),
   );
 

--- a/src/main.js
+++ b/src/main.js
@@ -101,8 +101,14 @@ export async function run() {
   // the profile's install-image pin, and the Factory publishes no unprefixed tag.
   const talosVersion = withV(qemu["talos-version"] ?? clientVersion);
   // The version the nodes will run, not just the binary: a pre-1.14 node rejects
-  // the typed config documents the profile emits.
-  if (isQemu) assertSupportedTargetVersion(talosVersion);
+  // the typed config documents the profile emits. On docker that version is the
+  // container image tag, when it carries one.
+  if (isQemu) {
+    assertSupportedTargetVersion(talosVersion);
+  } else {
+    const imageTag = /:(v?\d+\.\d+\.\d+\S*)$/.exec(cluster.spec?.docker?.image ?? "")?.[1];
+    if (imageTag) assertSupportedTargetVersion(imageTag, "the spec.docker.image tag");
+  }
 
   const vars = substitutions({ schematicId, cluster, talosVersion, gateway: addresses.gateway });
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,14 @@ import path from "node:path";
 import * as core from "@actions/core";
 import { exec } from "@actions/exec";
 
-import { bootAssetsDir, bootAssetsKey, restoreBootAssets, saveBootAssets } from "./cache.js";
+import {
+  bootAssetsDir,
+  bootAssetsKey,
+  preseedBootAssets,
+  restoreBootAssets,
+  saveBootAssets,
+} from "./cache.js";
+import { bootAsset, installerImage } from "./factory.js";
 import { loadCluster, validateSocketPath } from "./config.js";
 import { buildArgs, hasMaintenancePreset, nodeAddresses, providerOf, withV } from "./args.js";
 import {
@@ -97,14 +104,32 @@ export async function run() {
 
   // Profile first: talosctl applies patches in order with a deep merge, so the
   // caller's patches override the profile key by key and leave the rest standing.
-  const profileOptions = { hasSchematic: Boolean(schematicId), provider };
   const patches = concatPatches(
-    resolveProfilePatches(profilePatches(profile, profileOptions), { vars }),
+    resolveProfilePatches(profilePatches(profile), { vars }),
     resolvePatches(cluster, { baseDir, vars }),
   );
 
-  for (const line of describeProfile(profile, profileOptions)) {
+  for (const line of describeProfile(profile)) {
     core.info(`profile ${profile}: ${line}`);
+  }
+
+  // The dev subcommand takes boot media as URLs rather than a schematic id, so
+  // the action builds the same Factory references the qemu subcommand's presets
+  // would have (see factory.js), and pins the install image the way the qemu
+  // subcommand's applyDefaultSettings does.
+  const factoryUrl = qemu["image-factory"]?.url;
+  const asset = isQemu
+    ? bootAsset({ presets: qemu.presets, factoryUrl, schematicId, talosVersion })
+    : undefined;
+  const installImage = isQemu
+    ? installerImage({ factoryUrl, schematicId, talosVersion, secureboot: asset.secureboot })
+    : undefined;
+
+  // dev has no --image-factory-auth; a private factory's boot media is fetched by
+  // the action itself, with credentials in headers rather than argv, into the
+  // URL-keyed cache talosctl checks before downloading anything.
+  if (isQemu && factoryAuth) {
+    await preseedBootAssets([asset.url], factoryAuth);
   }
 
   for (const patch of [...patches.cluster, ...patches.controlplanes, ...patches.workers]) {
@@ -146,7 +171,13 @@ export async function run() {
   const talosconfig = path.join(configDir, "talosconfig");
   const kubeconfig = path.join(configDir, "kubeconfig");
 
-  const args = buildArgs(cluster, { schematicId, patches, talosconfig });
+  const args = buildArgs(cluster, {
+    patches,
+    talosconfig,
+    talosVersion,
+    bootAsset: asset,
+    installImage,
+  });
 
   // The QEMU provisioner's first preflight check is `os.Geteuid() != 0`, so root is
   // not a nicety there, it is a hard gate. `-E` matters as much as the elevation:

--- a/src/profile.js
+++ b/src/profile.js
@@ -40,20 +40,20 @@ const KERNEL_ARGS = [
 // Borrowed from kind. A node's disk holds two full sets of Kubernetes images plus the
 // Talos installer; if kubelet's default thresholds trip partway through a run it
 // garbage-collects images and evicts pods, which reads as a flaky test rather than a
-// disk problem. Nothing here is reclaimed anyway, the VM is deleted.
+// disk problem. Nothing here is reclaimed anyway, the VM is deleted. Written as the
+// 1.14 KubeletConfig document: a 1.14-contract config generates that document, and
+// Talos rejects a bundle that also sets .machine.kubelet in the v1alpha1 sections.
 const KUBELET_GC = {
   name: "kubelet GC and eviction thresholds",
   patch: {
-    machine: {
-      kubelet: {
-        extraConfig: {
-          imageGCHighThresholdPercent: 100,
-          evictionHard: {
-            "nodefs.available": "0%",
-            "nodefs.inodesFree": "0%",
-            "imagefs.available": "0%",
-          },
-        },
+    apiVersion: "v1alpha1",
+    kind: "KubeletConfig",
+    config: {
+      imageGCHighThresholdPercent: 100,
+      evictionHard: {
+        "nodefs.available": "0%",
+        "nodefs.inodesFree": "0%",
+        "imagefs.available": "0%",
       },
     },
   },
@@ -68,13 +68,11 @@ const KUBELET_GC = {
 const IMAGE_PULLS = {
   name: "parallel image pulls",
   patch: {
-    machine: {
-      kubelet: {
-        extraConfig: {
-          serializeImagePulls: false,
-          maxParallelImagePulls: 3,
-        },
-      },
+    apiVersion: "v1alpha1",
+    kind: "KubeletConfig",
+    config: {
+      serializeImagePulls: false,
+      maxParallelImagePulls: 3,
     },
   },
 };
@@ -91,13 +89,20 @@ const TIME_SYNC = {
   patch: { machine: { time: { disabled: true } } },
 };
 
-// talosctl hard-codes EnableClusterDiscovery, and its qemu subcommand exposes no flag
-// to turn it off, so every throwaway cluster registers its nodes as affiliates with the
-// public discovery service at discovery.talos.dev. Nothing here needs it: the nodes sit
-// on a local bridge at addresses the provisioner assigned, and KubeSpan is off.
-const DISCOVERY = {
+// Nothing here needs the public discovery service: the nodes sit on a local bridge
+// at addresses the provisioner assigned, and KubeSpan is off. The qemu provider
+// turns it off at generation time (--with-cluster-discovery=false, so no
+// DiscoveryServiceConfig document is emitted at all); the docker subcommand has no
+// such flag, so there the profile deletes the generated document instead. Wanting
+// it back on means adding your own DiscoveryServiceConfig document.
+const DISCOVERY_DELETE = {
   name: "cluster discovery service off",
-  patch: { cluster: { discovery: { enabled: false } } },
+  patch: {
+    apiVersion: "v1alpha1",
+    kind: "DiscoveryServiceConfig",
+    name: "default",
+    $patch: "delete",
+  },
 };
 
 // Trades durability for I/O, which is the right trade for a cluster that is destroyed
@@ -109,15 +114,13 @@ const ETCD_FSYNC = {
 };
 
 // Talos logs every API request at Metadata level to /var/log/audit/kube. Nothing
-// reads it here.
+// reads it here. The 1.14 document form; its `configuration` merges by replacement.
 const AUDIT_POLICY = {
   name: "apiserver audit policy off",
   patch: {
-    cluster: {
-      apiServer: {
-        auditPolicy: { apiVersion: "audit.k8s.io/v1", kind: "Policy", rules: [{ level: "None" }] },
-      },
-    },
+    apiVersion: "v1alpha1",
+    kind: "KubeAuditPolicyConfig",
+    configuration: { apiVersion: "audit.k8s.io/v1", kind: "Policy", rules: [{ level: "None" }] },
   },
 };
 
@@ -131,14 +134,17 @@ export function profileKernelArgs(profile, provider = DEFAULT_PROVIDER) {
 
 /**
  * Patches the profile contributes, by role. Emitted before the caller's own patches
- * so that theirs win. The install image is not among them: the action always pins
- * it via --install-image, the same way `cluster create qemu` pins it itself.
+ * so that theirs win. The install image is not among them (the action always pins
+ * it via --install-image), and neither is discovery on the qemu provider (turned
+ * off at generation time via --with-cluster-discovery=false).
  */
-export function profilePatches(profile) {
+export function profilePatches(profile, provider = DEFAULT_PROVIDER) {
   if (profile !== "ephemeral") return emptyPatches();
 
+  const cluster = [KUBELET_GC, IMAGE_PULLS, TIME_SYNC];
+
   return {
-    cluster: [KUBELET_GC, IMAGE_PULLS, TIME_SYNC, DISCOVERY],
+    cluster: provider === "docker" ? [...cluster, DISCOVERY_DELETE] : cluster,
     controlplanes: [ETCD_FSYNC, AUDIT_POLICY],
     workers: [],
   };
@@ -148,11 +154,12 @@ export function profilePatches(profile) {
 export function describeProfile(profile, { provider = DEFAULT_PROVIDER } = {}) {
   if (profile !== "ephemeral") return [];
 
-  const { cluster, controlplanes, workers } = profilePatches(profile);
+  const { cluster, controlplanes, workers } = profilePatches(profile, provider);
   const args = profileKernelArgs(profile, provider);
 
   return [
     ...(args.length ? [`kernel args: ${args.join(" ")}`] : []),
     ...[...cluster, ...controlplanes, ...workers].map((entry) => entry.name),
+    ...(provider === "docker" ? [] : ["cluster discovery service off"]),
   ];
 }

--- a/src/profile.js
+++ b/src/profile.js
@@ -100,18 +100,6 @@ const DISCOVERY = {
   patch: { cluster: { discovery: { enabled: false } } },
 };
 
-// talosctl never sets machine.install.image, so nodes come up on the generic
-// installer. On the first `talosctl upgrade` that silently drops every extension the
-// schematic baked in. Only meaningful when a schematic is in play.
-const INSTALL_IMAGE = {
-  name: "install image pinned to the schematic",
-  patch: {
-    machine: {
-      install: { image: "factory.talos.dev/installer/${SCHEMATIC_ID}:${TALOS_VERSION}" },
-    },
-  },
-};
-
 // Trades durability for I/O, which is the right trade for a cluster that is destroyed
 // at the end of the run. Talos only rejects the etcd args it manages for cluster
 // membership, so this one passes through.
@@ -143,26 +131,25 @@ export function profileKernelArgs(profile, provider = DEFAULT_PROVIDER) {
 
 /**
  * Patches the profile contributes, by role. Emitted before the caller's own patches
- * so that theirs win.
+ * so that theirs win. The install image is not among them: the action always pins
+ * it via --install-image, the same way `cluster create qemu` pins it itself.
  */
-export function profilePatches(profile, { hasSchematic = false } = {}) {
+export function profilePatches(profile) {
   if (profile !== "ephemeral") return emptyPatches();
 
-  const cluster = [KUBELET_GC, IMAGE_PULLS, TIME_SYNC, DISCOVERY];
-
   return {
-    cluster: hasSchematic ? [...cluster, INSTALL_IMAGE] : cluster,
+    cluster: [KUBELET_GC, IMAGE_PULLS, TIME_SYNC, DISCOVERY],
     controlplanes: [ETCD_FSYNC, AUDIT_POLICY],
     workers: [],
   };
 }
 
 /** One line per thing the profile did, so a run never applies anything unannounced. */
-export function describeProfile(profile, options = {}) {
+export function describeProfile(profile, { provider = DEFAULT_PROVIDER } = {}) {
   if (profile !== "ephemeral") return [];
 
-  const { cluster, controlplanes, workers } = profilePatches(profile, options);
-  const args = profileKernelArgs(profile, options.provider);
+  const { cluster, controlplanes, workers } = profilePatches(profile);
+  const args = profileKernelArgs(profile, provider);
 
   return [
     ...(args.length ? [`kernel args: ${args.join(" ")}`] : []),

--- a/src/talosctl.js
+++ b/src/talosctl.js
@@ -67,12 +67,11 @@ async function defaultTalosVersion(binary) {
   return parseVersionOutput(stdout);
 }
 
-// v1.12 split `cluster create` into `qemu` and `docker` subcommands, but the floor is
-// v1.13 because the action emits flags that landed after that split: v1.12 has no
-// --image-factory-auth, and its disk parser is a SplitN(":", 2) that cannot read the
-// :tag= / :serial= parameters this schema accepts. Gating on v1.12 would admit users
-// who then hit the bare cobra errors this check exists to prevent.
-export const MINIMUM_TALOS_VERSION = "1.13.0";
+// This action targets Talos 1.14: the ephemeral profile is written as the typed
+// config documents (KubeletConfig, KubeAuditPolicyConfig) that 1.14-contract
+// configs generate, and a pre-1.14 node rejects those kinds as unknown. Repos on
+// older Talos should pin an older action release rather than upgrade.
+export const MINIMUM_TALOS_VERSION = "1.14.0";
 
 const parseVersion = (tag) =>
   (tag ?? "")
@@ -108,11 +107,25 @@ export async function assertUsableVersion(binary) {
 
   if (!meetsMinimum(version)) {
     throw new Error(
-      `talosctl ${version} is too old: this action needs at least v${MINIMUM_TALOS_VERSION}, ` +
-        "which is where `cluster create` gained the `qemu` and `docker` subcommands and the " +
-        "flag names used here.",
+      `talosctl ${version} is too old: this action targets Talos v${MINIMUM_TALOS_VERSION} and ` +
+        "newer, whose configs use the typed multi-documents the ephemeral profile is written " +
+        "as. Pin an older release of this action for older Talos.",
     );
   }
 
   return version;
+}
+
+/**
+ * The same floor for the Talos version the nodes will run: the profile's typed
+ * documents are unknown kinds to a pre-1.14 node, which rejects the whole config.
+ */
+export function assertSupportedTargetVersion(talosVersion) {
+  if (!meetsMinimum(talosVersion)) {
+    throw new Error(
+      `spec.qemu.talos-version ${talosVersion} is below v${MINIMUM_TALOS_VERSION}: this action ` +
+        "targets Talos 1.14+, whose configs carry the typed documents the ephemeral profile " +
+        "emits. Pin an older release of this action for older Talos.",
+    );
+  }
 }

--- a/src/talosctl.js
+++ b/src/talosctl.js
@@ -119,13 +119,16 @@ export async function assertUsableVersion(binary) {
 /**
  * The same floor for the Talos version the nodes will run: the profile's typed
  * documents are unknown kinds to a pre-1.14 node, which rejects the whole config.
+ * On qemu that version is spec.qemu.talos-version; on docker it is the container
+ * image tag. Caught here as a clear error instead of ten minutes of handshake
+ * failures against a node that rejected its config.
  */
-export function assertSupportedTargetVersion(talosVersion) {
+export function assertSupportedTargetVersion(talosVersion, source = "spec.qemu.talos-version") {
   if (!meetsMinimum(talosVersion)) {
     throw new Error(
-      `spec.qemu.talos-version ${talosVersion} is below v${MINIMUM_TALOS_VERSION}: this action ` +
-        "targets Talos 1.14+, whose configs carry the typed documents the ephemeral profile " +
-        "emits. Pin an older release of this action for older Talos.",
+      `${source} ${talosVersion} is below v${MINIMUM_TALOS_VERSION}: this action targets ` +
+        "Talos 1.14+, whose configs carry the typed documents the ephemeral profile emits. " +
+        "Pin an older release of this action for older Talos.",
     );
   }
 }

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -22,6 +22,7 @@ describe("buildArgs", () => {
       "dev",
       "--name",
       "dev",
+      "--with-cluster-discovery=false",
       "--skip-injecting-config",
       "--with-apply-config",
     ]);

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { buildArgs, hasMaintenancePreset, nodeAddresses } from "../src/args.js";
+import { buildArgs, hasMaintenancePreset, nodeAddresses, translateDisks } from "../src/args.js";
 
 const cluster = (spec) => ({
   apiVersion: "v1alpha1",
@@ -15,8 +15,16 @@ const valueOf = (args, flag) => args[args.indexOf(flag) + 1];
 const valuesOf = (args, flag) => args.flatMap((arg, i) => (arg === flag ? [args[i + 1]] : []));
 
 describe("buildArgs", () => {
-  it("always targets the qemu subcommand with a name", () => {
-    assert.deepEqual(buildArgs(cluster()), ["cluster", "create", "qemu", "--name", "dev"]);
+  it("drives the qemu provider through the dev subcommand", () => {
+    assert.deepEqual(buildArgs(cluster()), [
+      "cluster",
+      "create",
+      "dev",
+      "--name",
+      "dev",
+      "--skip-injecting-config",
+      "--with-apply-config",
+    ]);
   });
 
   it("tolerates a document with no spec", () => {
@@ -25,29 +33,20 @@ describe("buildArgs", () => {
 
   it("omits flags the spec does not set, leaving talosctl defaults alone", () => {
     const args = buildArgs(cluster({}));
-    for (const flag of ["--controlplanes", "--workers", "--cidr", "--disks", "--presets"]) {
+    for (const flag of ["--controlplanes", "--workers", "--cidr", "--disk", "--extra-disks"]) {
       assert.ok(!args.includes(flag), `expected ${flag} to be absent`);
     }
   });
 
-  // talosctl is asymmetric here and gets this wrong silently if you are not.
-  it("normalises the v prefix per flag", () => {
-    const args = buildArgs(
-      cluster({ qemu: { "talos-version": "1.13.6" }, "kubernetes-version": "v1.34.0" }),
-    );
-    assert.equal(valueOf(args, "--talos-version"), "v1.13.6");
+  it("passes the caller-resolved talos version and normalises the kubernetes one", () => {
+    const args = buildArgs(cluster({ "kubernetes-version": "v1.34.0" }), {
+      talosVersion: "v1.13.7",
+    });
+    assert.equal(valueOf(args, "--talos-version"), "v1.13.7");
     assert.equal(valueOf(args, "--kubernetes-version"), "1.34.0");
   });
 
-  it("leaves already-normalised versions alone", () => {
-    const args = buildArgs(
-      cluster({ qemu: { "talos-version": "v1.13.6" }, "kubernetes-version": "1.34.0" }),
-    );
-    assert.equal(valueOf(args, "--talos-version"), "v1.13.6");
-    assert.equal(valueOf(args, "--kubernetes-version"), "1.34.0");
-  });
-
-  it("maps per-role cpu and memory to their own flags", () => {
+  it("maps per-role cpu and memory to the dev flag names", () => {
     const args = buildArgs(
       cluster({
         controlplanes: { count: 3, cpus: 2, memory: "2GiB" },
@@ -55,8 +54,8 @@ describe("buildArgs", () => {
       }),
     );
     assert.equal(valueOf(args, "--controlplanes"), "3");
-    assert.equal(valueOf(args, "--cpus-controlplanes"), "2");
-    assert.equal(valueOf(args, "--memory-controlplanes"), "2GiB");
+    assert.equal(valueOf(args, "--cpus"), "2");
+    assert.equal(valueOf(args, "--memory"), "2GiB");
     assert.equal(valueOf(args, "--workers"), "2");
     assert.equal(valueOf(args, "--cpus-workers"), "4");
     assert.equal(valueOf(args, "--memory-workers"), "5GiB");
@@ -67,29 +66,101 @@ describe("buildArgs", () => {
     assert.equal(valueOf(args, "--workers"), "0");
   });
 
-  // The Disks pflag.Value replaces on every Set, so repeated flags would drop all
-  // but the last disk.
-  it("joins disks into a single flag", () => {
-    const args = buildArgs(cluster({ qemu: { disks: ["virtio:8GiB", "virtio:20GiB"] } }));
-    assert.deepEqual(valuesOf(args, "--disks"), ["virtio:8GiB,virtio:20GiB"]);
+  it("translates disks onto the dev disk flags", () => {
+    const args = buildArgs(
+      cluster({ qemu: { disks: ["virtio:8GiB", "virtio:20GiB", "nvme:20GiB:serial=abc"] } }),
+    );
+    assert.equal(valueOf(args, "--disk"), "8192");
+    assert.equal(valueOf(args, "--extra-disks"), "2");
+    assert.equal(valueOf(args, "--extra-disks-size"), "20480");
+    assert.equal(valueOf(args, "--extra-disks-drivers"), "virtio,nvme");
+    assert.equal(valueOf(args, "--extra-disks-serials"), ",abc");
   });
 
-  it("repeats config-patch flags per role", () => {
+  it("emits only the primary disk flag for a single-entry list", () => {
+    const args = buildArgs(cluster({ qemu: { disks: ["virtio:6GiB"] } }));
+    assert.equal(valueOf(args, "--disk"), "6144");
+    assert.ok(!args.includes("--extra-disks"));
+  });
+
+  it("repeats config-patch flags per role, using the dev role names", () => {
     const args = buildArgs(cluster({}), {
       patches: { cluster: ['{"a":1}', '{"b":2}'], controlplanes: ['{"c":3}'], workers: [] },
     });
     assert.deepEqual(valuesOf(args, "--config-patch"), ['{"a":1}', '{"b":2}']);
-    assert.deepEqual(valuesOf(args, "--config-patch-controlplanes"), ['{"c":3}']);
-    assert.ok(!args.includes("--config-patch-workers"));
+    assert.deepEqual(valuesOf(args, "--config-patch-control-plane"), ['{"c":3}']);
+    assert.ok(!args.includes("--config-patch-worker"));
   });
 
-  it("passes the resolved schematic id and talosconfig destination", () => {
+  it("passes the boot asset, install image, and talosconfig from the caller", () => {
     const args = buildArgs(cluster({}), {
-      schematicId: "abc123",
+      bootAsset: {
+        flag: "--iso-path",
+        url: "https://factory.talos.dev/image/x/v1/metal-amd64.iso",
+      },
+      installImage: "factory.talos.dev/metal-installer/x:v1",
       talosconfig: "/tmp/dev/talosconfig",
     });
-    assert.equal(valueOf(args, "--schematic-id"), "abc123");
-    assert.equal(valueOf(args, "--talosconfig-destination"), "/tmp/dev/talosconfig");
+    assert.equal(
+      valueOf(args, "--iso-path"),
+      "https://factory.talos.dev/image/x/v1/metal-amd64.iso",
+    );
+    assert.equal(valueOf(args, "--install-image"), "factory.talos.dev/metal-installer/x:v1");
+    assert.equal(valueOf(args, "--talosconfig"), "/tmp/dev/talosconfig");
+  });
+
+  // Mirrors iso_secureboot_preset.go: TPM 2.0 plus TPM-keyed disk encryption.
+  it("expands the secureboot boot asset into the TPM and encryption flags", () => {
+    const args = buildArgs(cluster({}), {
+      bootAsset: { flag: "--iso-path", url: "https://x/secureboot.iso", secureboot: true },
+    });
+    for (const flag of ["--with-tpm2", "--encrypt-state", "--encrypt-ephemeral"]) {
+      assert.ok(args.includes(flag), `expected ${flag}`);
+    }
+    assert.equal(valueOf(args, "--disk-encryption-key-types"), "tpm");
+  });
+
+  // Replicates the qemu subcommand's lifecycle: config over the API, except under
+  // the maintenance preset, where nothing is applied and nothing can be waited on.
+  it("applies config over the API, or waits for nothing under maintenance", () => {
+    const normal = buildArgs(cluster({}));
+    assert.ok(normal.includes("--skip-injecting-config"));
+    assert.ok(normal.includes("--with-apply-config"));
+
+    const maintenance = buildArgs(cluster({ qemu: { presets: ["iso", "maintenance"] } }));
+    assert.ok(maintenance.includes("--skip-injecting-config"));
+    assert.ok(maintenance.includes("--wait=false"));
+    assert.ok(!maintenance.includes("--with-apply-config"));
+  });
+});
+
+describe("translateDisks", () => {
+  it("rejects a non-virtio primary disk with the reason", () => {
+    assert.throws(() => translateDisks(["nvme:10GiB"]), /primary disk must be virtio/);
+  });
+
+  it("rejects mixed extra disk sizes with the reason", () => {
+    assert.throws(
+      () => translateDisks(["virtio:6GiB", "virtio:10GiB", "virtio:20GiB"]),
+      /extra disks must all be the same size/,
+    );
+  });
+
+  it("rejects tags and serials on the primary disk", () => {
+    assert.throws(() => translateDisks(["virtio:6GiB:tag=x"]), /only available on extra disks/);
+  });
+
+  it("converts sizes to the MB the dev flags expect", () => {
+    assert.equal(translateDisks(["virtio:6GiB"]).disk, 6144);
+    assert.equal(translateDisks(["virtio:512MiB"]).disk, 512);
+    assert.equal(translateDisks(["virtio:1TiB"]).disk, 1048576);
+  });
+
+  it("carries per-disk drivers, tags, and serials for the extras", () => {
+    const disks = translateDisks(["virtio:6GiB", "virtio:5GiB:tag=data", "nvme:5GiB:serial=s1"]);
+    assert.deepEqual(disks.drivers, ["virtio", "nvme"]);
+    assert.deepEqual(disks.tags, ["data", ""]);
+    assert.deepEqual(disks.serials, ["", "s1"]);
   });
 });
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -59,7 +59,6 @@ spec:
       () => parseCluster(`${minimal}spec:\n  network:\n    cidr: 10.5.0.0/24\n    ipv6: true\n`),
       (err) => {
         assert.match(err.message, /spec\.network\.ipv6/);
-        assert.match(err.message, /cluster create dev/);
         assert.match(err.message, /config-patches/);
         return true;
       },

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -1,0 +1,77 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  bootAsset,
+  bootMethodOf,
+  installerImage,
+  EMPTY_SCHEMATIC_ID,
+  talosArch,
+} from "../src/factory.js";
+
+const base = { schematicId: "abc", talosVersion: "v1.13.7", arch: "amd64" };
+
+describe("bootAsset", () => {
+  // The default must be byte-identical to what `cluster create qemu`'s iso preset
+  // would have downloaded, or the migration changes what nodes boot.
+  it("builds the iso preset's URL by default", () => {
+    assert.deepEqual(bootAsset(base), {
+      flag: "--iso-path",
+      url: "https://factory.talos.dev/image/abc/v1.13.7/metal-amd64.iso",
+      secureboot: false,
+    });
+  });
+
+  it("substitutes the well-known empty schematic when none was registered", () => {
+    assert.match(
+      bootAsset({ ...base, schematicId: undefined }).url,
+      new RegExp(EMPTY_SCHEMATIC_ID),
+    );
+  });
+
+  it("maps each boot-method preset onto its dev flag and asset path", () => {
+    assert.equal(bootAsset({ ...base, presets: ["disk-image"] }).flag, "--disk-image-path");
+    assert.match(bootAsset({ ...base, presets: ["disk-image"] }).url, /metal-amd64\.raw\.zst$/);
+
+    const pxe = bootAsset({ ...base, presets: ["pxe", "maintenance"] });
+    assert.equal(pxe.flag, "--ipxe-boot-script");
+    assert.equal(pxe.url, "https://factory.talos.dev/pxe/abc/v1.13.7/metal-amd64");
+
+    const secureboot = bootAsset({ ...base, presets: ["iso-secureboot"] });
+    assert.equal(secureboot.secureboot, true);
+    assert.match(secureboot.url, /metal-amd64-secureboot\.iso$/);
+  });
+
+  it("ignores the maintenance preset when picking the boot method", () => {
+    assert.equal(bootMethodOf(["maintenance"]), "iso");
+    assert.equal(bootMethodOf(["iso", "maintenance"]), "iso");
+    assert.equal(bootMethodOf(undefined), "iso");
+  });
+});
+
+describe("installerImage", () => {
+  it("pins the schematic installer the way applyDefaultSettings does", () => {
+    assert.equal(installerImage(base), "factory.talos.dev/metal-installer/abc:v1.13.7");
+  });
+
+  it("uses the secureboot installer for secureboot media", () => {
+    assert.equal(
+      installerImage({ ...base, secureboot: true }),
+      "factory.talos.dev/metal-installer-secureboot/abc:v1.13.7",
+    );
+  });
+
+  it("keeps only the host of a path-carrying factory URL, since it is an image ref", () => {
+    assert.equal(
+      installerImage({ ...base, factoryUrl: "https://factory.internal/image-factory" }),
+      "factory.internal/metal-installer/abc:v1.13.7",
+    );
+  });
+});
+
+describe("talosArch", () => {
+  it("maps node arch names to Talos arch names", () => {
+    assert.equal(talosArch("x64"), "amd64");
+    assert.equal(talosArch("arm64"), "arm64");
+  });
+});

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -49,10 +49,32 @@ describe("profile", () => {
 
   // Both are valid in a worker's cluster/machine section as well as a control plane's,
   // so they ride the all-node patch rather than being split per role.
-  it("turns off time sync and cluster discovery on every node", () => {
+  it("turns off time sync on every node", () => {
     const cluster = JSON.stringify(profilePatches("ephemeral").cluster);
     assert.match(cluster, /"time":\{"disabled":true\}/);
-    assert.match(cluster, /"discovery":\{"enabled":false\}/);
+  });
+
+  // On the qemu provider discovery is off at generation time, so no patch; the
+  // docker subcommand has no such flag, so the generated 1.14 document is deleted.
+  it("deletes the discovery document on docker only", () => {
+    const qemu = JSON.stringify(profilePatches("ephemeral").cluster);
+    assert.doesNotMatch(qemu, /DiscoveryServiceConfig/);
+
+    const docker = JSON.stringify(profilePatches("ephemeral", "docker").cluster);
+    assert.match(docker, /"kind":"DiscoveryServiceConfig"/);
+    assert.match(docker, /"\$patch":"delete"/);
+  });
+
+  // The 1.14 contract generates typed documents for these areas and rejects a
+  // bundle that also sets them in the v1alpha1 sections.
+  it("writes kubelet and audit settings as their 1.14 typed documents", () => {
+    const cluster = JSON.stringify(profilePatches("ephemeral").cluster);
+    assert.match(cluster, /"kind":"KubeletConfig"/);
+    assert.doesNotMatch(cluster, /machine.*kubelet/);
+
+    const cp = JSON.stringify(profilePatches("ephemeral").controlplanes);
+    assert.match(cp, /"kind":"KubeAuditPolicyConfig"/);
+    assert.doesNotMatch(cp, /apiServer/);
   });
 
   it("puts etcd and audit settings on control planes only", () => {
@@ -61,7 +83,7 @@ describe("profile", () => {
     const patches = profilePatches("ephemeral");
     const cp = JSON.stringify(patches.controlplanes);
     assert.match(cp, /unsafe-no-fsync/);
-    assert.match(cp, /auditPolicy/);
+    assert.match(cp, /KubeAuditPolicyConfig/);
     assert.doesNotMatch(JSON.stringify(patches.cluster), /unsafe-no-fsync/);
     assert.deepEqual(patches.workers, []);
   });

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -7,15 +7,8 @@ import {
   describeProfile,
   DEFAULT_PROFILE,
 } from "../src/profile.js";
-import { concatPatches, resolvePatch, substitutions } from "../src/patches.js";
+import { concatPatches } from "../src/patches.js";
 import { withKernelArgs } from "../src/schematic.js";
-import { parseCluster } from "../src/config.js";
-import { withV } from "../src/args.js";
-
-// Through parseCluster so the fixture cannot drift into a shape the schema rejects.
-const cluster = parseCluster(
-  "apiVersion: v1alpha1\nkind: TalosCluster\nmetadata:\n  name: dev\nspec:\n  qemu:\n    talos-version: v1.13.6\n",
-);
 
 describe("profile", () => {
   it("defaults to ephemeral", () => {
@@ -73,50 +66,21 @@ describe("profile", () => {
     assert.deepEqual(patches.workers, []);
   });
 
-  it("pins the install image only when a schematic is in play", () => {
-    const without = JSON.stringify(profilePatches("ephemeral", { hasSchematic: false }).cluster);
-    const with_ = JSON.stringify(profilePatches("ephemeral", { hasSchematic: true }).cluster);
-    assert.doesNotMatch(without, /install/);
-    assert.match(with_, /factory\.talos\.dev\/installer/);
-  });
-
-  const pinnedImage = (vars) => {
-    const { cluster } = profilePatches("ephemeral", { hasSchematic: true });
-    const installImage = cluster.find((entry) => entry.name.includes("install image"));
-    return JSON.parse(resolvePatch(installImage.patch, { vars })).machine.install.image;
-  };
-
-  it("resolves the pinned image against the registered schematic", () => {
-    const vars = substitutions({ schematicId: "abc123", cluster, talosVersion: "v1.13.6" });
-    assert.equal(pinnedImage(vars), "factory.talos.dev/installer/abc123:v1.13.6");
-  });
-
-  // The flag is v-normalised, and the pinned image has to be too: the Image Factory
-  // publishes no unprefixed tag, so an unprefixed pin fails at first upgrade.
-  it("pins a v-prefixed tag even when the spec omits the v", () => {
-    const vars = substitutions({
-      schematicId: "abc123",
-      cluster,
-      talosVersion: withV("1.13.6"),
-    });
-    assert.equal(pinnedImage(vars), "factory.talos.dev/installer/abc123:v1.13.6");
-  });
-
-  it("falls back to talosctl's own version when the spec omits one", () => {
-    const bare = { ...cluster, spec: {} };
-    const vars = substitutions({ schematicId: "abc", cluster: bare, talosVersion: "v1.13.6" });
-    assert.equal(pinnedImage(vars), "factory.talos.dev/installer/abc:v1.13.6");
+  // The install image pin is not a profile patch: the action passes
+  // --install-image itself, the way `cluster create qemu` pins it internally.
+  it("never patches the install image", () => {
+    assert.doesNotMatch(JSON.stringify(profilePatches("ephemeral")), /install/);
   });
 
   it("names everything it applied, so nothing is silent", () => {
-    const lines = describeProfile("ephemeral", { hasSchematic: true });
+    const lines = describeProfile("ephemeral");
     assert.match(lines.join("\n"), /kernel args/);
     assert.match(lines.join("\n"), /kubelet/);
     assert.match(lines.join("\n"), /parallel image pulls/);
     assert.match(lines.join("\n"), /etcd/);
     assert.match(lines.join("\n"), /time sync/);
     assert.match(lines.join("\n"), /discovery/);
-    assert.equal(lines.length, 8);
+    assert.equal(lines.length, 7);
   });
 });
 

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -17,10 +17,10 @@ const valueOf = (args, flag) => args[args.indexOf(flag) + 1];
 const envelope = "apiVersion: v1alpha1\nkind: TalosCluster\nmetadata:\n  name: dev\n";
 
 describe("provider selection", () => {
-  it("defaults to qemu", () => {
+  it("defaults to qemu, driven through the dev subcommand", () => {
     assert.equal(DEFAULT_PROVIDER, "qemu");
     assert.equal(providerOf(cluster({})), "qemu");
-    assert.equal(buildArgs(cluster({}))[2], "qemu");
+    assert.equal(buildArgs(cluster({}))[2], "dev");
   });
 
   it("targets the docker subcommand when asked", () => {

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -133,32 +133,30 @@ describe("profile under docker", () => {
     assert.deepEqual(profileKernelArgs("ephemeral", "docker"), []);
     assert.ok(profileKernelArgs("ephemeral", "qemu").length > 0);
 
-    const patches = profilePatches("ephemeral", { provider: "docker", hasSchematic: false });
+    const patches = profilePatches("ephemeral", "docker");
     assert.match(JSON.stringify(patches.cluster), /imageGCHighThresholdPercent/);
     assert.match(JSON.stringify(patches.cluster), /serializeImagePulls/);
     assert.match(JSON.stringify(patches.controlplanes), /unsafe-no-fsync/);
-    // No schematic means nothing to pin an install image to.
     assert.doesNotMatch(JSON.stringify(patches.cluster), /install/);
   });
 });
 
-// v1.12 introduced the qemu/docker subcommands, but the floor is v1.13: the action
-// emits --image-factory-auth and accepts :tag=/:serial= disk parameters, neither of
-// which v1.12 understands. Gating on v1.12 would admit users straight into the bare
-// cobra errors this check exists to prevent.
+// The floor is v1.14: the profile is written as the typed config documents that
+// 1.14-contract configs generate, and a pre-1.14 node rejects those kinds. Repos on
+// older Talos pin an older action release instead of upgrading.
 describe("talosctl minimum version", () => {
   it("requires the release that supports every flag the action emits", () => {
-    assert.equal(MINIMUM_TALOS_VERSION, "1.13.0");
+    assert.equal(MINIMUM_TALOS_VERSION, "1.14.0");
   });
 
   it("rejects releases older than that, including the subcommand release itself", () => {
-    for (const v of ["v1.12.0", "1.12.9", "v1.11.0", "v1.9.3", "0.14.0"]) {
+    for (const v of ["v1.13.7", "1.13.0", "v1.12.9", "v1.9.3", "0.14.0"]) {
       assert.equal(meetsMinimum(v), false, v);
     }
   });
 
   it("accepts that release and newer", () => {
-    for (const v of ["v1.13.0", "1.13.6", "v1.14.0", "v2.0.0"]) {
+    for (const v of ["v1.14.0", "1.14.2", "v1.15.0", "v2.0.0"]) {
       assert.equal(meetsMinimum(v), true, v);
     }
   });
@@ -170,7 +168,7 @@ describe("talosctl minimum version", () => {
   });
 
   it("handles pre-release and build suffixes", () => {
-    assert.equal(meetsMinimum("v1.13.0-alpha.1"), true);
-    assert.equal(meetsMinimum("v1.12.0-beta.2"), false);
+    assert.equal(meetsMinimum("v1.14.0-beta.1"), true);
+    assert.equal(meetsMinimum("v1.13.0-beta.2"), false);
   });
 });

--- a/test/schematic.test.js
+++ b/test/schematic.test.js
@@ -13,7 +13,7 @@ import {
 } from "../src/schematic.js";
 import { parseCluster } from "../src/config.js";
 import { profileKernelArgs } from "../src/profile.js";
-import { buildArgs } from "../src/args.js";
+import { bootAsset } from "../src/factory.js";
 
 const envelope = "apiVersion: v1alpha1\nkind: TalosCluster\nmetadata:\n  name: dev\n";
 
@@ -88,20 +88,16 @@ describe("image factory url", () => {
     assert.equal(DEFAULT_FACTORY_URL, "https://factory.talos.dev/");
   });
 
-  it("omits the flag when the spec names no factory, leaving talosctl's default", () => {
-    assert.ok(!buildArgs({ metadata: { name: "x" }, spec: {} }).includes("--image-factory-url"));
-  });
-
-  it("passes a custom factory to talosctl", () => {
-    const cluster = {
-      metadata: { name: "x" },
-      spec: { qemu: { "image-factory": { url: "https://ci.internal/image-factory" } } },
-    };
-    const args = buildArgs(cluster);
-    assert.equal(
-      args[args.indexOf("--image-factory-url") + 1],
-      "https://ci.internal/image-factory",
-    );
+  // The factory URL is no longer a talosctl flag: the dev subcommand takes fully
+  // built asset URLs, so the custom factory shows up inside them instead.
+  it("feeds a custom factory into the built asset URLs", () => {
+    const asset = bootAsset({
+      factoryUrl: "https://ci.internal/image-factory",
+      schematicId: "abc",
+      talosVersion: "v1.13.7",
+      arch: "amd64",
+    });
+    assert.equal(asset.url, "https://ci.internal/image-factory/image/abc/v1.13.7/metal-amd64.iso");
   });
 
   it("keeps a base path when building its own endpoint", async () => {


### PR DESCRIPTION
Migrates the qemu provider's backend from `talosctl cluster create qemu` to `talosctl cluster create dev`, per the maintainer guidance that the qemu subcommand's flag surface is frozen and `dev` is the sanctioned full-flag interface. Consumers keep the same declarative spec; the dialect change is internal.

## What stays identical

The action pins the exact behavior the qemu subcommand had, verified by a [parity spike](https://github.com/home-operations/talosctl-cluster-action/actions/runs/30646462037) (identical booted cmdlines including schematic kernel args through the post-install kexec, extra worker disk present, warm-create timing equal: 93s dev vs 97s control to node Ready):

- **Boot media**: [factory.js](src/factory.js) builds the same Factory URLs the qemu subcommand's presets build (`iso`, `iso-secureboot`, `pxe`, `disk-image`; empty-schematic constant when none is registered), passed as `--iso-path`/`--disk-image-path`/`--ipxe-boot-script`. `iso-secureboot` expands to the same TPM + disk-encryption flags the upstream preset sets.
- **Lifecycle**: `--skip-injecting-config --with-apply-config` replicates boot-to-maintenance + API apply. The maintenance preset maps to `--skip-injecting-config --wait=false` plus the existing TCP readiness wait.
- **Install image**: always pinned via `--install-image <factory-host>/metal-installer/<schematic>:<version>`, mirroring the qemu subcommand's `applyDefaultSettings`. The ephemeral profile's install-image patch is gone as redundant.
- **Caching**: `cache: true` carries over unchanged — the dev path shares `downloadBootAssets` and `~/.talos/cache`.

## Breaking changes

- `spec.qemu.disks`: the primary disk must be **virtio** with no `tag=`/`serial=`, and **extra disks must all share one size** (per-disk drivers/tags/serials remain). Both are validation errors with the reason; the dev subcommand's count-based disk flags cannot express more.
- `spec.qemu.image-factory.auth`: no longer passed as `--image-factory-auth` (dev has no such flag). The action pre-downloads boot media itself with HTTP Basic **in headers** into talosctl's URL-keyed asset cache — strictly better secret handling than the argv flag.
- Stability posture: `dev` makes no interface promise between talosctl releases. This action's e2e pins the tested version; a talosctl minor the action has not caught up with may need an action release first. Documented in the README's Providers section.

## Notes for review

- The `--extra-boot-kernel-args`/`install.extraKernelArgs` mechanisms were deliberately **not** adopted: PR #44's spike proved the post-install kexec boots the installer UKI's embedded cmdline, so schematics remain the only correct kernel-arg mechanism. The profile's schematic flow is unchanged.
- Follow-ups this unblocks (not in this PR): `spec.network.ipv6`, network chaos flags for storage/e2e testing, disk encryption without secureboot.
- The e2e matrix (`minimal`/`full`/`docker`/`maintenance`) runs against the migrated backend in this PR's CI, which is the real gate.

137 unit tests pass; `dist/` rebuilt.


## Addendum: targets Talos 1.14

Per review discussion, the action now targets Talos 1.14 as its floor rather than special-casing it:

- The ephemeral profile is written as the **1.14 typed config documents** (`KubeletConfig`, `KubeAuditPolicyConfig`), fixing #46: 1.14-contract configs generate those documents and reject bundles that also set the same areas in the v1alpha1 sections. Discovery is off at generation time on qemu (`--with-cluster-discovery=false`, no `DiscoveryServiceConfig` document emitted) and a `$patch: delete` of the generated document on docker.
- `MINIMUM_TALOS_VERSION` is v1.14.0 for both the talosctl binary and the spec's `talos-version` (a pre-1.14 node rejects the typed documents as unknown kinds). Repos on older Talos pin an older action release.
- CI and mise run v1.14.0-beta.1 everywhere; the dedicated `talosctl-next` leg is gone while the main pin *is* the newest release (it returns when 1.15 alphas exist).
- Consumer patches to `.machine.kubelet`, `.cluster.apiServer`, or `.cluster.discovery` hit the same 1.14 rejection; the README documents the typed-document shapes.
