### PR TITLE
fix: keep node disks sparse on the dev backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,13 @@ either is a validation error rather than a silent reshaping: the **first disk mu
 virtio** (and carries no `tag=`/`serial=`), and the **extra disks must all be the same
 size**. Extras keep per-disk drivers, tags, and serials.
 
+Disks are always **sparse**: the dev subcommand defaults to preallocating them, which
+turns a spec's nominal sizes into real bytes and fills a CI runner's disk before the
+first node boots, so the action pins the qemu subcommand's old sparse behavior. And
+when a spec names no disks at all, talosctl's default is now a single 6GiB disk per
+node — the previous subcommand defaulted to 10GiB plus a 6GiB extra on workers, so a
+test that relied on that implicit second disk must declare it.
+
 ### Patches and schematics
 
 Both take an inline object or an `"@path"` string, resolved relative to the config

--- a/dist/index.js
+++ b/dist/index.js
@@ -98365,6 +98365,13 @@ function buildArgs(cluster, ctx = {}) {
     // applyDefaultSettings.
     push("--install-image", ctx.installImage);
 
+    // The dev subcommand registers --disk-preallocate with a literal default of
+    // true, unlike the qemu subcommand, which kept the option's false default and
+    // created sparse disks. Preallocation quietly multiplies a spec's nominal disk
+    // sizes into real bytes and fills a CI runner's disk before the first node
+    // boots; sparse is both the parity behavior and the only one that fits.
+    args.push("--disk-preallocate=false");
+
     // No DiscoveryServiceConfig document is generated at all, which is how 1.14
     // configs turn the public discovery service off. A spec that wants it back
     // adds its own document via config-patches.

--- a/src/args.js
+++ b/src/args.js
@@ -160,6 +160,13 @@ export function buildArgs(cluster, ctx = {}) {
     // applyDefaultSettings.
     push("--install-image", ctx.installImage);
 
+    // The dev subcommand registers --disk-preallocate with a literal default of
+    // true, unlike the qemu subcommand, which kept the option's false default and
+    // created sparse disks. Preallocation quietly multiplies a spec's nominal disk
+    // sizes into real bytes and fills a CI runner's disk before the first node
+    // boots; sparse is both the parity behavior and the only one that fits.
+    args.push("--disk-preallocate=false");
+
     // No DiscoveryServiceConfig document is generated at all, which is how 1.14
     // configs turn the public discovery service off. A spec that wants it back
     // adds its own document via config-patches.

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -22,6 +22,7 @@ describe("buildArgs", () => {
       "dev",
       "--name",
       "dev",
+      "--disk-preallocate=false",
       "--with-cluster-discovery=false",
       "--skip-injecting-config",
       "--with-apply-config",


### PR DESCRIPTION
Caught by the v0.2.0 rollout to miroir ([miroir#385](https://github.com/home-operations/miroir/pull/385)): every qemu e2e leg died with `No space left on device` before logs could even flush. The dev subcommand registers `--disk-preallocate` with a literal default of **true** ([cmd_dev.go](https://github.com/siderolabs/talos/blob/v1.14.0-beta.1/cmd/talosctl/cmd/mgmt/cluster/create/cmd_dev.go#L212)), unlike the qemu subcommand, which never registers the flag and inherits the option's **false** default ([options.go#L206](https://github.com/siderolabs/talos/blob/v1.14.0-beta.1/cmd/talosctl/cmd/mgmt/cluster/create/clusterops/options.go#L206)) — sparse disks. Preallocation turns miroir's ~150GB of nominal DRBD disk into real bytes on a runner with ~20GB free.

The action now always passes `--disk-preallocate=false`: parity with the old backend, and the only behavior that fits a hosted runner. A sweep of `cmd_dev.go` for other literal-default divergences found just one more, `--extra-disks-on-controlplanes=false`, which already matches.

Also documents the one remaining default-disk difference: a spec naming no disks gets dev's single 6GiB per node rather than the old subcommand's 10GiB + 6GiB worker extra (the action's own examples and all known consumers declare disks explicitly).

The action's own e2e passed on v0.2.0 only because its example specs total ~28GB nominal, just under the runner's free space — miroir's bigger shapes exposed it immediately.