### PR TITLE
ci: run the e2e job through the $/ self-repository reference

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Create cluster
         id: cluster
-        uses: ./
+        uses: $/
         with:
           config: examples/${{ matrix.example }}.yaml
           cache: ${{ matrix.cache || false }}
@@ -324,7 +324,7 @@ jobs:
           echo "zizmor=$(mise config get tools.zizmor)" >> "$GITHUB_OUTPUT"
 
       - name: Lint workflows
-        uses: home-operations/.github/actions/workflow-lint@5514ee499e8919d394b5376637025535dac84ff8 # workflow-lint-v1.0.2
+        uses: home-operations/.github/actions/workflow-lint@69cad1e407df8070dd9cfc3314551e473544014e # workflow-lint-v1.0.3
         with:
           actionlint-version: ${{ steps.tools.outputs.actionlint }}
           zizmor-version: ${{ steps.tools.outputs.zizmor }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,8 +1,5 @@
 ---
-rules:
-  # The e2e job runs the action from the checkout under test (`uses: ./`), which
-  # is the only way to exercise it before release. The reviewed code and the code
-  # being run are the same commit.
-  unpinned-uses:
-    ignore:
-      - ci.yaml
+# No suppressions needed: the e2e job's `uses: $/` self-repository reference
+# resolves to this repo at the running commit, which zizmor treats as local
+# rather than unpinned.
+rules: {}


### PR DESCRIPTION
Follow-up to #55, unblocked by workflow-lint v1.0.3 (home-operations/.github#79):

- Bump `workflow-lint` v1.0.2 → v1.0.3, whose actionlint ignore regexes (`\$/.*`) cover the bare `$/` form.
- Switch the e2e job from `uses: ./` to `uses: $/`. Both run the action at the exact commit under test; the checkout stays for `examples/`.
- zizmor treats `$/` as a local reference rather than unpinned, so the `unpinned-uses` suppression in `.github/zizmor.yml` is no longer needed; the file is left as an empty-ruleset stub, delete it if you prefer.