### PR TITLE
chore(talos): update talos to v1.14.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ permissions:
 
 env:
   # renovate: datasource=github-releases depName=siderolabs/talos
-  TALOS_VERSION: v1.14.0-beta.1
+  TALOS_VERSION: v1.14.0
 
 jobs:
   bundle-freshness:

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -22,7 +22,7 @@ yq = "4.53.6"
 # Only used by `mise run e2e` to exercise the action against a real cluster on a
 # KVM-capable host. Consumers pin their own talosctl; the action resolves whatever
 # the caller provides.
-talosctl = "1.14.0-beta.1"
+talosctl = "1.14.0"
 
 [tasks.install]
 description = "Install npm dependencies from the lockfile"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -119,25 +119,25 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056932"
 
 [[tools.talosctl]]
-version = "1.14.0-beta.1"
+version = "1.14.0"
 backend = "aqua:siderolabs/talos"
 
 [tools.talosctl."platforms.linux-arm64"]
-checksum = "sha256:9d546ccdc0f2df58234f94bb988d1c8d1a512017819c1a6cc4d60647ad810e2f"
-url = "https://github.com/siderolabs/talos/releases/download/v1.14.0-beta.1/talosctl-linux-arm64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/496642705"
+checksum = "sha256:19615e1d0eb222de86ec2f1487e7d6e74f5171a9038e73aeacde8cc647e3d9e0"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0/talosctl-linux-arm64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/542359013"
 provenance = "cosign"
 
 [tools.talosctl."platforms.linux-x64"]
-checksum = "sha256:367842b0ea4db95756ced4681808b0a8f4ccc637fff1344c9eb1b5d292bdcd31"
-url = "https://github.com/siderolabs/talos/releases/download/v1.14.0-beta.1/talosctl-linux-amd64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/496642710"
+checksum = "sha256:2c147c4a99d124c95bd5c190fe054e0b3c93495f2243fd652ebd423adb8377c7"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0/talosctl-linux-amd64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/542359015"
 provenance = "cosign"
 
 [tools.talosctl."platforms.macos-arm64"]
-checksum = "sha256:ded9121c64dad4dd49947282a5d751daf5c6c53c9ba79232398f866c3f41daa2"
-url = "https://github.com/siderolabs/talos/releases/download/v1.14.0-beta.1/talosctl-darwin-arm64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/496642692"
+checksum = "sha256:f0c65a0e970b6f23cf0160e432e7496ba93957a49f369780d4e53888ed66ef46"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0/talosctl-darwin-arm64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/542359001"
 provenance = "cosign"
 
 [[tools.yq]]

--- a/README.md
+++ b/README.md
@@ -84,12 +84,7 @@ mutation in your workflow, where you can see it. Both providers need `talosctl`
 
 ```yaml
 - name: Install talosctl
-  env:
-    # renovate: datasource=github-releases depName=siderolabs/talos
-    TALOS_VERSION: v1.14.0
-  run: |
-    curl -sfL "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-amd64" -o talosctl
-    sudo install -m 0755 talosctl /usr/local/bin/talosctl
+  run: curl -sL https://talos.dev/install | sh
 
 - name: Install QEMU
   run: |
@@ -117,12 +112,7 @@ runners and the runner user is already in the `docker` group, so no install is n
 
 ```yaml
 - name: Install talosctl
-  env:
-    # renovate: datasource=github-releases depName=siderolabs/talos
-    TALOS_VERSION: v1.14.0
-  run: |
-    curl -sfL "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-amd64" -o talosctl
-    sudo install -m 0755 talosctl /usr/local/bin/talosctl
+  run: curl -sL https://talos.dev/install | sh
 
 # The nodes are containers on the runner's kernel, so flannel runs against host modules
 # it cannot load itself. Without br_netfilter its `bridge-nf-call-iptables` probe fails,

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ mutation in your workflow, where you can see it. Both providers need `talosctl`
 - name: Install talosctl
   env:
     # renovate: datasource=github-releases depName=siderolabs/talos
-    TALOS_VERSION: v1.14.0-beta.1
+    TALOS_VERSION: v1.14.0
   run: |
     curl -sfL "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-amd64" -o talosctl
     sudo install -m 0755 talosctl /usr/local/bin/talosctl
@@ -119,7 +119,7 @@ runners and the runner user is already in the `docker` group, so no install is n
 - name: Install talosctl
   env:
     # renovate: datasource=github-releases depName=siderolabs/talos
-    TALOS_VERSION: v1.14.0-beta.1
+    TALOS_VERSION: v1.14.0
   run: |
     curl -sfL "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-amd64" -o talosctl
     sudo install -m 0755 talosctl /usr/local/bin/talosctl
@@ -497,7 +497,7 @@ metadata:
   name: e2e-3cp-0w
 spec:
   qemu:
-    talos-version: v1.14.0-beta.1
+    talos-version: v1.14.0
   controlplanes:
     count: 3
   workers:

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -22,7 +22,7 @@ spec:
 
   docker:
     # docker's equivalent of the qemu provider's talos-version.
-    image: ghcr.io/siderolabs/talos:v1.14.0-beta.1
+    image: ghcr.io/siderolabs/talos:v1.14.0
 
   # The profile still applies the parts that make sense here: the kubelet, etcd, and
   # audit settings. Its kernel args are skipped, because those ride in an Image

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -24,7 +24,7 @@ spec:
     cidr: 10.5.0.0/24
 
   qemu:
-    talos-version: v1.14.0-beta.1
+    talos-version: v1.14.0
 
     # The first disk goes to every node; the second is attached to workers only.
     disks:

--- a/examples/matrix/1cp-0w.yaml
+++ b/examples/matrix/1cp-0w.yaml
@@ -9,7 +9,7 @@ metadata:
   name: e2e-1cp-0w
 spec:
   qemu:
-    talos-version: v1.14.0-beta.1
+    talos-version: v1.14.0
   controlplanes:
     count: 1
   workers:

--- a/examples/matrix/1cp-1w.yaml
+++ b/examples/matrix/1cp-1w.yaml
@@ -9,7 +9,7 @@ metadata:
   name: e2e-1cp-1w
 spec:
   qemu:
-    talos-version: v1.14.0-beta.1
+    talos-version: v1.14.0
   controlplanes:
     count: 1
   workers:

--- a/examples/matrix/3cp-0w.yaml
+++ b/examples/matrix/3cp-0w.yaml
@@ -10,7 +10,7 @@ metadata:
   name: e2e-3cp-0w
 spec:
   qemu:
-    talos-version: v1.14.0-beta.1
+    talos-version: v1.14.0
   controlplanes:
     count: 3
   workers:


### PR DESCRIPTION
Talos v1.14.0 was released today as a stable release. This moves every pin from `v1.14.0-beta.1` to `v1.14.0`:

- the e2e `talosctl` download in `ci.yaml`
- the mise `talosctl` tool and its lockfile (checksums regenerated for all three platforms; the linux-amd64 checksum matches upstream's `sha256sum.txt`)
- the README install snippets and example
- `examples/full.yaml`, `examples/docker.yaml`, and the matrix specs

The v1.14.0 release notes show no changes to the flags the action passes to `talosctl cluster create`. Unit tests, lint, format, and the dist staleness check pass locally; the qemu e2e is left to CI.